### PR TITLE
docs: update placeholder usernames to be more explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Feature requests are welcome! Please:
 
 ```bash
 # Clone your fork
-git clone https://github.com/yourusername/atlas.git
+git clone https://github.com/<your-username>/atlas.git
 cd atlas
 
 # Create feature branch

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -62,7 +62,7 @@ At minimum, set the following:
 
 ```bash
 # Directory containing the two GGUF files
-ATLAS_MODELS_DIR="/home/yourusername/models"
+ATLAS_MODELS_DIR="<your-models-path>"
 
 # Directory for persistent data (indexes, training data, projects)
 ATLAS_DATA_DIR="/opt/atlas/data"


### PR DESCRIPTION
## Summary
This PR updates placeholder usernames and paths in documentation to use angle bracket format (`<placeholder>`) which is more commonly recognized as a placeholder in technical documentation.

## Changes
- `CONTRIBUTING.md`: Change `yourusername` to `<your-username>` in git clone example
- `docs/SETUP.md`: Change `/home/yourusername/models` to `<your-models-path>`

## Impact
- Makes it clearer that these are placeholder values that need to be replaced
- Follows common documentation conventions for placeholders

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>