### PR TITLE
fix: image existence check for docker runtime

### DIFF
--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -58,7 +58,7 @@ import_to_k3s() {
     log_info "Importing $name to K3s..."
 
     # Check if image exists
-    if ! $runtime image exists "${ATLAS_REGISTRY}/$name:${ATLAS_IMAGE_TAG}" 2>/dev/null; then
+    if ! $runtime image inspect "${ATLAS_REGISTRY}/$name:${ATLAS_IMAGE_TAG}" &>/dev/null; then
         log_warn "Image ${ATLAS_REGISTRY}/$name:${ATLAS_IMAGE_TAG} not found, skipping import"
         return 0
     fi


### PR DESCRIPTION
Call `${runtime} image inspect` in scripts/build-containers.sh instead of `${runtime} image exists` since `docker image exists` is not a real command.
Redirect stdin in addition to stdout to /dev/null since `inspect` subcommand has actual output.

Fixes #12