### PR TITLE
fix(benchmark): correct Geometric Lens default port (8001 -> 8099)

### DIFF
--- a/benchmark/v3/lens_feedback.py
+++ b/benchmark/v3/lens_feedback.py
@@ -29,7 +29,7 @@ class LensFeedbackConfig:
     retrain_interval: int = 50
     min_pass: int = 5
     min_fail: int = 5
-    rag_api_url: str = "http://geometric-lens.atlas.svc.cluster.local:8001"
+    rag_api_url: str = "http://geometric-lens.atlas.svc.cluster.local:8099"
     domain: str = "LCB"
     use_replay: bool = True
     use_ewc: bool = True


### PR DESCRIPTION
Closes #21.

One-line default-value fix in `benchmark/v3/lens_feedback.py:32`:

```diff
-    rag_api_url: str = "http://geometric-lens.atlas.svc.cluster.local:8001"
+    rag_api_url: str = "http://geometric-lens.atlas.svc.cluster.local:8099"
```

`LensFeedbackConfig.rag_api_url` pointed at port 8001, but the Geometric Lens service itself listens on 8099 (`geometric-lens/config.py:9` -> `port: int = 8099`). The mismatch is dormant in production because `LensFeedbackConfig.enabled` defaults to `False`, but a fresh deployment that flips the feature on without overriding `rag_api_url` would silently try to hit the wrong port.

No other 8001 references exist in the Python tree (`grep -rn 8001 --include='*.py'` returns only this line), so this single change is the whole fix.