### PR TITLE
[AMD]add RDNA4 (gfx1200/gfx1201) support to ROCm7.2 setup

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -745,6 +745,10 @@ Common values:
 | `gfx90a` | CDNA2 | MI210, MI250, MI250X |
 | `gfx942` | CDNA3 | MI300X |
 | `gfx900` | Vega | Vega 56/64 (may need HSA override — see TROUBLESHOOTING.md) |
+| `gfx1200` | RDNA4 (Navi 44) | RX 9070 |
+| `gfx1201` | RDNA4 (Navi 48) | RX 9070 XT |
+
+> **RDNA4 (gfx1200/gfx1201) users:** set `ATLAS_ROCM_TAG=7.2.3-complete` — the default ROCm 6.2 base image does not include gfx1200/gfx1201 compiler support. ROCm 7.0+ supports these targets natively; do not set `ATLAS_HSA_OVERRIDE_GFX_VERSION`. See [TROUBLESHOOTING.md § RDNA4](TROUBLESHOOTING.md) for details.
 
 Your GPU's gfx target: `rocminfo | grep -i gfx | head -1` (or look it up in the [LLVM AMDGPU processor table](https://llvm.org/docs/AMDGPUUsage.html)).
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -213,6 +213,32 @@ docker compose -f docker-compose.yml -f docker-compose.rocm.yml up -d --force-re
 
 If this works for you on a previously-unsupported card, please leave a note on [GH #26](https://github.com/itigges22/ATLAS/issues/26) — community-tested overrides feed into the next release's docs.
 
+
+### RDNA4 (RX 9070 / 9070 XT, gfx1200 / gfx1201) — ROCm 7.x required
+
+**Symptom:** Build fails during `docker compose ... build llama-server` with errors like `error: AMDGPU target 'gfx1201' is not supported`, or the container starts but immediately exits with a HIP initialization error.
+
+**What it means:** The default ROCm base image (`rocm/dev-ubuntu-22.04:6.2-complete`) predates RDNA4. The gfx1200 and gfx1201 compiler targets were added in ROCm 7.0 — see the [ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html) for the full supported hardware list.
+
+**Fix:** Set `ATLAS_ROCM_TAG` to a ROCm 7.x tag before building:
+
+```env
+# Add to your .env
+ATLAS_ROCM_TAG=7.2.3-complete
+ATLAS_GFX_TARGET=gfx1201   # gfx1200 for RX 9070, gfx1201 for RX 9070 XT
+```
+
+Then rebuild and bring up the stack:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.rocm.yml build llama-server
+docker compose -f docker-compose.yml -f docker-compose.rocm.yml up -d
+```
+
+**Important: do NOT set `ATLAS_HSA_OVERRIDE_GFX_VERSION` for gfx1200/gfx1201.** ROCm 7.0+ supports these targets natively; overriding the GFX version inside Docker causes a mismatch between the compiled kernels and the runtime target, which results in crashes. Leave `ATLAS_HSA_OVERRIDE_GFX_VERSION` unset (the default).
+
+> Tested on AMD Radeon AI PRO R9700 (gfx1201) with ROCm 7.2, `ATLAS_ROCM_TAG=7.2.3-complete`. ATLAS PC-202 patch applies cleanly to the pinned llama.cpp SHA. Inference runs correctly across text generation and embedding generation without any additional flags.
+
 ### ROCm container can't pull `rocm/rocm-terminal`
 
 **Symptom:** `atlas doctor` ROCm check times out at the image pull, or `docker compose -f ... -f docker-compose.rocm.yml pull` fails on the `llama-server` build.


### PR DESCRIPTION
## What this PR does

Adds RDNA4 support documentation for RX 9070 / RX 9070 XT (gfx1200 / gfx1201) to the AMD ROCm setup path, covering two gaps that currently cause silent failures for users on this hardware:

**`docs/SETUP.md`** — adds `gfx1200` and `gfx1201` rows to the AMD GPU targets table, with a note that RDNA4 requires `ATLAS_ROCM_TAG=7.2.3-complete` (the default ROCm 6.2 base image predates these targets).

**`docs/TROUBLESHOOTING.md`** — adds a `### RDNA4 (RX 9070 / 9070 XT)` section with symptom, root cause, fix commands, and an explicit warning not to set `ATLAS_HSA_OVERRIDE_GFX_VERSION` — ROCm 7.0+ supports gfx1200/gfx1201 natively and overriding it causes a kernel/runtime target mismatch that crashes the container.

## Testing

Tested on AMD Radeon AI PRO R9700 (gfx1201) with `ATLAS_ROCM_TAG=7.2.3-complete` and `ATLAS_GFX_TARGET=gfx1201`:

- Docker build completes successfully
- `expose-hidden-states.patch` applies cleanly to the pinned llama.cpp SHA
- Text generation inference works correctly
- Embedding endpoint (`/v1/embeddings`) works correctly — Geometric Lens path functional
- `ATLAS_HSA_OVERRIDE_GFX_VERSION` unset throughout; gfx1201 recognized natively by ROCm 7.2
- Tests: python tests/validate_tests.py — ✅ All tests pass integrity check

## Checklist items from #26

- [x] Add ROCm section to `docs/SETUP.md`
- [x] Add ROCm troubleshooting to `docs/TROUBLESHOOTING.md`
<img width="1849" height="1064" alt="image-20260528144818508" src="https://github.com/user-attachments/assets/3cf8cdc3-f497-47b6-bfec-6b181bba89e8" />
