### PR TITLE
Registry: add Lens artifacts for gemma-4-12b-it-Q4_K_M (via atlas lens publish)

### DIFF
--- a/atlas/cli/commands/model_registry.py
+++ b/atlas/cli/commands/model_registry.py
@@ -327,6 +327,22 @@ REGISTRY: List[Model] = [
               "llama.cpp model only — G(x) verification will silently "
               "no-op (--no-lens to acknowledge). See PC-058 roadmap.",
     ),
+    Model(
+        name="gemma-4-12b-it-Q4_K_M",
+        tier="medium",
+        model_file="gemma-4-12b-it-Q4_K_M.gguf",
+        model_display="gemma-4-12b-it-Q4_K_M",
+        model_size_gb=6.6,
+        lens_status="supported",
+        download_url=None,
+        sha256=None,
+        license="apache-2.0",
+        lens_artifact_files=["cost_field.pt", "cost_field.safetensors", "gx_xgboost.json", "gx_weights.json"],
+        notes="Added via `atlas lens publish` — lens artifacts "
+              "(3840-dim) at https://huggingface.co/itigges22/atlas-lens-gemma4-12b. "
+              "download_url not captured at publish time; maintainers "
+              "can fill it in for `atlas model install` support.",
+    ),
 ]
 
 


### PR DESCRIPTION
## Add Lens artifacts for `gemma-4-12b-it-Q4_K_M` (auto-generated by `atlas lens publish`)

### Summary

User-trained Geometric Lens cost-field for `gemma-4-12b-it-Q4_K_M`, uploaded to
HuggingFace at https://huggingface.co/itigges22/atlas-lens-gemma4-12b.

### Verification checklist (maintainer review per PC-059)

- [ ] HF link reachable: https://huggingface.co/itigges22/atlas-lens-gemma4-12b
- [ ] License is permissive for redistribution (apache-2.0)
- [ ] `cost_field.pt` SHA256 matches: `82b2d960b71b84a90ecc69189c67bc72a9b7cbc5c79b7b207dcaf2634b0af509`
- [ ] Artifact input dim (3840) matches the base model's embedding dim
- [ ] Spot-check: download + run `atlas lens check` against the base model

### Suggested registry diff

Add the following to `atlas/cli/commands/model_registry.py` (or update
the existing entry's `lens_status` from `no-artifacts`/`unverified`
to `supported`):

```python
Model(
    name="gemma-4-12b-it-Q4_K_M",
    # ... existing tier / model_file / model_size_gb / download_url ...
    lens_status="supported",
    lens_artifact_dir=None,  # uses ATLAS_LENS_MODELS dir; per-model layout TBD by PC-058 follow-on
    lens_artifact_files=['cost_field.pt', 'cost_field.safetensors', 'gx_xgboost.json', 'gx_weights.json'],
    license="apache-2.0",
),
```

### Provenance

Trained locally via `atlas lens build` against `gemma-4-12b-it-Q4_K_M`. Contrast
the merged behavior with the prior `lens_status: {no-artifacts | unverified}`
state — `atlas doctor` should stop warning about lens drift on this model
once the PR merges.
