### PR TITLE
Registry: add ASA vector for gemma-4-12b-it-Q4_K_M (via atlas asa publish)

### DIFF
--- a/atlas/cli/commands/model_registry.py
+++ b/atlas/cli/commands/model_registry.py
@@ -342,6 +342,8 @@ REGISTRY: List[Model] = [
               "(3840-dim) at https://huggingface.co/itigges22/atlas-lens-gemma4-12b. "
               "download_url not captured at publish time; maintainers "
               "can fill it in for `atlas model install` support.",
+        asa_status="supported",
+        asa_artifact_files=["ast_edit_steering.gguf"],
     ),
 ]
 


### PR DESCRIPTION
## Add ASA control vector for `gemma-4-12b-it-Q4_K_M` (auto-generated by `atlas asa publish`)

### Summary

User-trained BiasBusters #4 ASA steering vector for `gemma-4-12b-it-Q4_K_M`,
uploaded to HuggingFace at https://huggingface.co/itigges22/atlas-asa-gemma4-12b.

### Verification checklist (maintainer review per PC-061)

- [ ] HF link reachable: https://huggingface.co/itigges22/atlas-asa-gemma4-12b
- [ ] License is permissive for redistribution (apache-2.0)
- [ ] `ast_edit_steering.gguf` SHA256 matches: `fbcfd8af85980c21fd0eb7d37c5627b027008934ad6c626b99eabf6e5587bb46`
- [ ] Residual dim (3840-dim) matches the base model
- [ ] Trained at layer 36 (paper recommendation: ~75% of model depth)
- [ ] Spot-check: drop the .gguf at `/models/ast_edit_steering.gguf` and
      confirm llama-server boots without `control_vector_load failed`
- [ ] Behavior smoke-test: pre-vs-post task that benefits from the bias
      (whole-function rewrite via `ast_edit` over `edit_file`)

### Suggested registry diff

Most ASA vectors are distributed alongside the Lens artifacts in the
same model entry. Add an `asa_artifact_files` field if the registry
doesn't already track ASA per-model (V3.1.2 work):

```python
Model(
    name="gemma-4-12b-it-Q4_K_M",
    # ... existing fields ...
    lens_status="supported",
    # New (V3.1.2 forward-compat): ASA vector tracking
    asa_artifact_files=["ast_edit_steering.gguf"],
    asa_status="supported",
    license="apache-2.0",
),
```

### Provenance

Trained locally via `atlas asa build` against `gemma-4-12b-it-Q4_K_M`. Algorithm:
mean-difference (positives−negatives) over per-token residuals at
layer 36, projected to a single direction. Same approach as the
Feb 2026 ASA paper (arxiv 2602.04935).


---
*Stacked on #121 (this model's entry lands there). Merge #121 with branch deletion and GitHub retargets this PR to `dev` automatically — its diff shows only this change.*