### PR TITLE
Registry: add Lens + ASA artifacts for gemma-4-12b-it-Q4_K_M (via atlas publish)

### DIFF
--- a/atlas/cli/commands/model_registry.py
+++ b/atlas/cli/commands/model_registry.py
@@ -342,6 +342,8 @@ REGISTRY: List[Model] = [
               "(3840-dim) at https://huggingface.co/itigges22/atlas-lens-gemma4-12b. "
               "download_url not captured at publish time; maintainers "
               "can fill it in for `atlas model install` support.",
+        # ASA vector: https://huggingface.co/itigges22/atlas-asa-gemma4-12b
+        # (promote to asa_hf_repo= once the registry schema carries it)
         asa_status="supported",
         asa_artifact_files=["ast_edit_steering.gguf"],
     ),

--- a/atlas/cli/commands/model_registry.py
+++ b/atlas/cli/commands/model_registry.py
@@ -327,6 +327,24 @@ REGISTRY: List[Model] = [
               "llama.cpp model only — G(x) verification will silently "
               "no-op (--no-lens to acknowledge). See PC-058 roadmap.",
     ),
+    Model(
+        name="gemma-4-12b-it-Q4_K_M",
+        tier="medium",
+        model_file="gemma-4-12b-it-Q4_K_M.gguf",
+        model_display="gemma-4-12b-it-Q4_K_M",
+        model_size_gb=6.6,
+        lens_status="supported",
+        download_url=None,
+        sha256=None,
+        license="apache-2.0",
+        lens_artifact_files=["cost_field.pt", "cost_field.safetensors", "gx_xgboost.json", "gx_weights.json"],
+        notes="Added via `atlas lens publish` — lens artifacts "
+              "(3840-dim) at https://huggingface.co/itigges22/atlas-lens-gemma4-12b. "
+              "download_url not captured at publish time; maintainers "
+              "can fill it in for `atlas model install` support.",
+        asa_status="supported",
+        asa_artifact_files=["ast_edit_steering.gguf"],
+    ),
 ]
 
 

--- a/atlas/cli/commands/model_registry.py
+++ b/atlas/cli/commands/model_registry.py
@@ -98,6 +98,10 @@ class Model:
     # `supported` claim to be honest. doctor.check_tier_match
     # cross-checks this — registered "supported" + missing files = warn.
     lens_artifact_files: List[str] = field(default_factory=list)
+    # PC-214: HuggingFace repo holding this model's published lens
+    # artifacts (`atlas lens publish` destination). None = unpublished;
+    # consumers download per the HF repo's model card.
+    lens_hf_repo: Optional[str] = None
     # Base URL where the lens_artifact_files live for download. The
     # installer appends each filename to this base. None = no auto-
     # download path; user has to train locally via `atlas lens build`
@@ -121,6 +125,8 @@ class Model:
     # open for multi-vector setups (per-layer banks) without a schema
     # change. doctor cross-checks alongside lens_artifact_files.
     asa_artifact_files: List[str] = field(default_factory=list)
+    # PC-214: HuggingFace repo holding this model's published ASA vector.
+    asa_hf_repo: Optional[str] = None
     # Base URL where the asa_artifact_files live for download. Same
     # contract as lens_artifact_url_base — installer appends each
     # filename and downloads to models_dir (NOT lens dir; ASA vectors
@@ -338,14 +344,14 @@ REGISTRY: List[Model] = [
         sha256=None,
         license="apache-2.0",
         lens_artifact_files=["cost_field.pt", "cost_field.safetensors", "gx_xgboost.json", "gx_weights.json"],
+        lens_hf_repo="itigges22/atlas-lens-gemma4-12b",
         notes="Added via `atlas lens publish` — lens artifacts "
               "(3840-dim) at https://huggingface.co/itigges22/atlas-lens-gemma4-12b. "
               "download_url not captured at publish time; maintainers "
               "can fill it in for `atlas model install` support.",
-        # ASA vector: https://huggingface.co/itigges22/atlas-asa-gemma4-12b
-        # (promote to asa_hf_repo= once the registry schema carries it)
         asa_status="supported",
         asa_artifact_files=["ast_edit_steering.gguf"],
+        asa_hf_repo="itigges22/atlas-asa-gemma4-12b",
     ),
 ]
 


### PR DESCRIPTION
## Add Lens artifacts for `gemma-4-12b-it-Q4_K_M` (auto-generated by `atlas lens publish`)

### Summary

User-trained Geometric Lens cost-field for `gemma-4-12b-it-Q4_K_M`, uploaded to
HuggingFace at https://huggingface.co/itigges22/atlas-lens-gemma4-12b.

### Verification checklist (maintainer review per PC-059)

- [ ] HF link reachable: https://huggingface.co/itigges22/atlas-lens-gemma4-12b
- [ ] License is permissive for redistribution (apache-2.0)
- [ ] `cost_field.pt` SHA256 matches: `82b2d960b71b84a90ecc69189c67bc72a9b7cbc5c79b7b207dcaf2634b0af509`
- [ ] Artifact input dim (3840) matches the base model's embedding dim
- [ ] Spot-check: download + run `atlas lens check` against the base model

### Suggested registry diff

Add the following to `atlas/cli/commands/model_registry.py` (or update
the existing entry's `lens_status` from `no-artifacts`/`unverified`
to `supported`):

```python
Model(
    name="gemma-4-12b-it-Q4_K_M",
    # ... existing tier / model_file / model_size_gb / download_url ...
    lens_status="supported",
    lens_artifact_dir=None,  # uses ATLAS_LENS_MODELS dir; per-model layout TBD by PC-058 follow-on
    lens_artifact_files=['cost_field.pt', 'cost_field.safetensors', 'gx_xgboost.json', 'gx_weights.json'],
    license="apache-2.0",
),
```

### Provenance

Trained locally via `atlas lens build` against `gemma-4-12b-it-Q4_K_M`. Contrast
the merged behavior with the prior `lens_status: {no-artifacts | unverified}`
state — `atlas doctor` should stop warning about lens drift on this model
once the PR merges.


---

## Add ASA control vector for `gemma-4-12b-it-Q4_K_M` (auto-generated by `atlas asa publish`)

### Summary

User-trained BiasBusters #4 ASA steering vector for `gemma-4-12b-it-Q4_K_M`,
uploaded to HuggingFace at https://huggingface.co/itigges22/atlas-asa-gemma4-12b.

### Verification checklist (maintainer review per PC-061)

- [ ] HF link reachable: https://huggingface.co/itigges22/atlas-asa-gemma4-12b
- [ ] License is permissive for redistribution (apache-2.0)
- [ ] `ast_edit_steering.gguf` SHA256 matches: `fbcfd8af85980c21fd0eb7d37c5627b027008934ad6c626b99eabf6e5587bb46`
- [ ] Residual dim (3840-dim) matches the base model
- [ ] Trained at layer 36 (paper recommendation: ~75% of model depth)
- [ ] Spot-check: drop the .gguf at `/models/ast_edit_steering.gguf` and
      confirm llama-server boots without `control_vector_load failed`
- [ ] Behavior smoke-test: pre-vs-post task that benefits from the bias
      (whole-function rewrite via `ast_edit` over `edit_file`)

### Suggested registry diff

Most ASA vectors are distributed alongside the Lens artifacts in the
same model entry. Add an `asa_artifact_files` field if the registry
doesn't already track ASA per-model (V3.1.2 work):

```python
Model(
    name="gemma-4-12b-it-Q4_K_M",
    # ... existing fields ...
    lens_status="supported",
    # New (V3.1.2 forward-compat): ASA vector tracking
    asa_artifact_files=["ast_edit_steering.gguf"],
    asa_status="supported",
    license="apache-2.0",
),
```

### Provenance

Trained locally via `atlas asa build` against `gemma-4-12b-it-Q4_K_M`. Algorithm:
mean-difference (positives−negatives) over per-token residuals at
layer 36, projected to a single direction. Same approach as the
Feb 2026 ASA paper (arxiv 2602.04935).
