### PR TITLE
feat(#39): structural call-graph reasoning (ATLAS_CALL_GRAPH)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ ATLAS_MODEL_NAME=Qwen3.5-9B-Q6_K
 # Context window size (tokens)
 ATLAS_CTX_SIZE=32768
 
+# Structural call-graph reasoning (#39, EXPERIMENTAL, default off). When 1/true,
+# v3-service builds a precomputed call graph and uses it to deepen the structural
+# veto, the repair context, and symbol-index injection. Strictly additive — off
+# leaves behavior unchanged. See docs/reports/CALL_GRAPH_REASONING_V3.md.
+# ATLAS_CALL_GRAPH=0
+
 # Host project directory bind-mounted to /workspace inside the proxy container.
 # This is the directory ATLAS reads and writes files in. The bind mount is
 # resolved at `docker compose up` time and is fixed for the container's

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           # tree-sitter grammars for the #39 call-graph extraction tests under
           # tests/v3-service/ (they skip cleanly if absent, but CI should run
           # them). Pre-built wheels, no build toolchain needed.
-          pip install tree_sitter tree_sitter_python
+          pip install tree_sitter tree_sitter_python tree_sitter_javascript
 
       - name: pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # tests/v3/ and tests/cli/ are pure unit tests — no services
-        # needed. tests/integration/ + tests/infrastructure/ require
-        # a live llama-server / sandbox / lens, gated separately by
+        # tests/v3/, tests/v3-service/, and tests/cli/ are pure unit tests —
+        # no services needed. tests/integration/ + tests/infrastructure/
+        # require a live llama-server / sandbox / lens, gated separately by
         # the integration workflow (not yet wired up — PC-064).
         subset:
           - tests/v3
+          - tests/v3-service
           - tests/cli
     steps:
       - uses: actions/checkout@v4
@@ -67,6 +68,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install pytest
+          # tree-sitter grammars for the #39 call-graph extraction tests under
+          # tests/v3-service/ (they skip cleanly if absent, but CI should run
+          # them). Pre-built wheels, no build toolchain needed.
+          pip install tree_sitter tree_sitter_python
 
       - name: pytest
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,9 @@ services:
       - ATLAS_LENS_URL=http://geometric-lens:8099
       - ATLAS_SANDBOX_URL=http://sandbox:8020
       - ATLAS_MODEL_NAME=${ATLAS_MODEL_NAME:-Qwen3.5-9B-Q6_K}
+      # Structural call-graph reasoning (#39, experimental, default off). Read by
+      # call_graph_enabled() inside this process, so it must be forwarded here.
+      - ATLAS_CALL_GRAPH=${ATLAS_CALL_GRAPH:-0}
     ports:
       - "${ATLAS_V3_PORT:-8070}:8070"
     depends_on:

--- a/docs/reports/CALL_GRAPH_REASONING_V3.md
+++ b/docs/reports/CALL_GRAPH_REASONING_V3.md
@@ -183,12 +183,16 @@ not just whose imports survive.
 **Goal:** when the user names a symbol, inject its graph neighborhood.
 
 - `graph/context.py` `symbol_neighborhood`: a symbol's callers, callees, impact
-  set, and defining files. Wired into the `/internal/symbol_index` endpoint as
+  set, and defining files. v3-service attaches it to `/internal/symbol_index` as
   an additive `graph` field (the `matched`/`skipped` shape is unchanged), gated
-  by `ATLAS_CALL_GRAPH`.
-- Tests in `test_graph_context.py`.
-- **Exit (met):** naming a symbol surfaces its structurally related code. The
-  fewer-exploration-turns claim needs the live L6 measurement.
+  by `ATLAS_CALL_GRAPH`, building the project graph once per request.
+- The proxy consumes it end to end: `symbolIndexResult.Graph` (`proxy/symbol_index.go`)
+  parses the field and `formatGraphNeighborhood` folds the callers/callees into
+  the injected `[system note]` context in `agent.go`. (A review caught this as
+  initially half-wired — produced but discarded — and it's now consumed.)
+- Tests: `test_graph_context.py` + Go `symbol_index_test.go` (parse + format).
+- **Exit (met):** naming a symbol injects its definitions plus its structural
+  neighborhood. The fewer-exploration-turns claim needs the live L6 measurement.
 
 ### Phase 4 — Tier enrichment (#39 point 2, low priority) — ◑ signal shipped
 **Goal:** optional graph signals in tier classification.

--- a/docs/reports/CALL_GRAPH_REASONING_V3.md
+++ b/docs/reports/CALL_GRAPH_REASONING_V3.md
@@ -166,54 +166,72 @@ not just whose imports survive.
   (a real NameError) that the shipped shape check let through, while staying
   lenient on opaque wildcards and attribute calls.
 
-### Phase 2 — Multi-hop repair context (#39 point 3)
+### Phase 2 — Multi-hop repair context (#39 point 3) — ✅ SHIPPED
 **Goal:** give the repair model the real call chain, not 1-hop neighbors.
 
-- Replace `call_chain_context`'s immediate callers/callees with a reachability
-  slice: the path(s) from entry points to the failing function, its transitive
-  callers (impact set), and its callees, bounded for token budget.
-- **Exit:** repair context for a deep failure includes the actual call path, not
-  just direct neighbors.
+- `graph/context.py` `repair_context`: a reachability slice — the call path from
+  an entry point down to the failing function, its transitive callers (impact
+  set) beyond the direct ones, and its callees, all bounded for token budget.
+- Wired in the pipeline `run` Phase-3 repair block, gated by `ATLAS_CALL_GRAPH`,
+  preferring the graph block and falling back to the shipped `call_chain_context`
+  on flag-off or any failure.
+- Tests in `test_graph_context.py`.
+- **Exit (met):** repair context for a deep failure includes the actual entry→
+  function call path and the transitive impact set, not just direct neighbors.
 
-### Phase 3 — Graph-scoped context injection (#39 point 4)
+### Phase 3 — Graph-scoped context injection (#39 point 4) — ✅ SHIPPED
 **Goal:** when the user names a symbol, inject its graph neighborhood.
 
-- Replace the name-match snippets in `symbol_index` with a graph slice: the
-  named symbol plus its callers, callees, and impact set, resolved across files.
-- **Exit:** naming a symbol pulls in the structurally related code, measured by
-  fewer model exploration turns on L6 tasks.
+- `graph/context.py` `symbol_neighborhood`: a symbol's callers, callees, impact
+  set, and defining files. Wired into the `/internal/symbol_index` endpoint as
+  an additive `graph` field (the `matched`/`skipped` shape is unchanged), gated
+  by `ATLAS_CALL_GRAPH`.
+- Tests in `test_graph_context.py`.
+- **Exit (met):** naming a symbol surfaces its structurally related code. The
+  fewer-exploration-turns claim needs the live L6 measurement.
 
-### Phase 4 — Tier enrichment (#39 point 2, low priority)
+### Phase 4 — Tier enrichment (#39 point 2, low priority) — ◑ signal shipped
 **Goal:** optional graph signals in tier classification.
 
-- Cyclomatic complexity already ships. Optionally fold in fan-in/fan-out or
-  reachability breadth as a secondary tier signal. Skip if it doesn't move tier
-  accuracy.
+- `analyses.complexity`: per-node fan-in/fan-out plus the graph maxima, exposed
+  via the `complexity` analysis on `/internal/call_graph`. Tests in
+  `test_graph_solver.py`.
+- Wiring into the Go tier classifier is intentionally **not** done: point 2
+  already ships via cyclomatic complexity, and the plan gates this on a tier-
+  accuracy measurement we can't run here. The signal is available for that
+  measurement to consume.
 
-### Phase 5 — Optional solver layer (the literal "+ solver")
+### Phase 5 — Optional solver layer (the literal "+ solver") — ✅ SHIPPED (dependency-free)
 **Goal:** custom rule-based queries native traversal can't express.
 
-- Emit Prolog facts from the graph using chiasmus's exact schema
-  (`defines/4`, `calls/2`, `calls_qn/3`, `imports/3`, `imports_resolved/3`,
-  `exports/2`, `contains/2`, `entry_point/1`, plus the `reaches`/`path`/
-  `func_reaches`/`dead` rules from `facts.ts`). Ship the facts artifact early
-  (cheap) so the solver can be added without re-plumbing.
-- Add a SWI-Prolog (Datalog-style) backend for transitive-closure queries under
-  custom constraints. Decide Prolog vs Datalog vs Z3 here; for call-graph
-  reachability, Prolog/Datalog fits and chiasmus uses SWI-Prolog WASM. As a
-  Python service this likely means a `pyswip`/subprocess SWI binding or a small
-  Datalog engine; a Node sidecar reusing chiasmus's solver is the alternative.
-- **Exit:** a custom reachability-under-constraints query the native layer can't
-  express returns a solver-verified answer. Strictly additive; native stays the
-  default path.
+- Prolog facts already emit from Phase 0 (`facts.py` `graph_to_prolog`,
+  exposed via the `facts` analysis) using chiasmus's schema, ready for an
+  external SWI-Prolog / `chiasmus_verify`.
+- `graph/datalog.py`: a compact, dependency-free in-process Datalog engine
+  (facts + structured rules → bounded naive fixpoint → query). Ships the
+  built-in transitive `reaches` closure (`reachable_pairs`, exposed as the
+  `closure` analysis) and supports arbitrary user rules in-process. Its `reaches`
+  is **cross-checked against `analyses.reachability` for all node pairs** in the
+  test suite, so the solver layer is provably consistent with the native one.
+- A real SWI-Prolog backend (`pyswip` / sidecar) for arbitrary external rules
+  remains an option; the facts artifact is the bridge and needs no re-plumbing.
+- **Exit (met):** the closure relation and arbitrary in-process rules evaluate
+  over the facts, dependency-free; native stays the default path.
 
-### Phase 6 — Multi-language
+### Phase 6 — Multi-language — ✅ SHIPPED (Python + JavaScript)
 **Goal:** beyond Python.
 
-- Generalize extraction via an adapter pattern (chiasmus `adapter-registry.ts`).
-  Ship Python plus JS/TS first (well-supported grammars, biggest user base, per
-  #39), install the grammars in `v3-service/Dockerfile`, add cross-file
-  resolution per language (tsconfig aliases for TS, etc.).
+- `extract.py` dispatches by extension to a Python or JavaScript walk; JS covers
+  defines / calls / imports / contains (function/class/method declarations,
+  `const` arrow/function defines, call and member-call expressions, named /
+  default / namespace imports). `build_graph` ingests both; analyses run on the
+  merged multi-language graph.
+- The `tree_sitter_javascript` grammar is added to the Dockerfile and CI.
+- **Golden parity** against chiasmus's `extractGraph` on a JS fixture (classes,
+  methods, arrow-const defines, member calls, `new` not counted as a call,
+  named/default imports) — defines, calls, and imports match exactly.
+- Tests in `test_graph_multilang.py`. TS (type nodes) and qualified-name
+  resolution are the natural next increment; JS uses bare names like Python.
 
 ## 7. Risks / open questions
 

--- a/docs/reports/CALL_GRAPH_REASONING_V3.md
+++ b/docs/reports/CALL_GRAPH_REASONING_V3.md
@@ -1,0 +1,247 @@
+# Structural code reasoning — precomputed call graph + reachability
+
+Tracks **[#39](https://github.com/itigges22/ATLAS/issues/39)**. Reference
+implementation: **chiasmus** (`~/src/chiasmus`), Dmitri Sotnikov's tree-sitter +
+solver engine, which the issue already credits as the inspiration.
+
+## 1. What we're building
+
+ATLAS shipped "v1 plus four follow-up points" of #39 in V3.1, but the
+architectural ask in the title, a call graph backed by tree-sitter that can
+answer transitive reachability, never landed. The maintainer's own honest read
+of the issue lists what is missing:
+
+- No precomputed call graph stored anywhere; tree-sitter walks happen ad-hoc per
+  request.
+- No transitive reachability. The "reachability slice" is symbol-name match, not
+  graph traversal across call edges.
+- The structural veto is a shape check ("does the import exist, does the class
+  def survive"), not "do the called functions resolve to reachable definitions."
+- No Prolog / Datalog / Z3 anywhere.
+
+This work builds the real layer: a **precomputed, cached call graph** with
+**native reachability queries**, and then rewires the four shipped integration
+points to use it instead of their shallow stand-ins. A logic solver is an
+optional final layer, not the foundation (see §3).
+
+## 2. The chiasmus lesson that reframes the issue
+
+The issue title says "tree-sitter + solver", and the help-wanted ask is for
+Prolog/Datalog/Z3 contributors. But chiasmus, the cited reference, does **not**
+use its solver for call-graph reachability. It computes callers, callees,
+reachability, paths, impact, dead code, and cycles **natively in JS in O(V+E)**
+(`src/graph/native-analyses.ts`: `reachability` is BFS, `cycles` is Tarjan SCC,
+`callers`/`callees` are reverse/forward BFS). It emits Prolog facts
+(`src/graph/facts.ts` `graphToProlog`) only so an optional `chiasmus_verify`
+step can run custom rule queries; the everyday structural questions never touch
+a solver.
+
+That is the right shape for ATLAS too. Native graph traversal is deterministic,
+fast, dependency-free, and trivially correct, which matters for a local tool on
+the proxy's latency budget. The solver earns its place only for queries native
+traversal can't express cleanly (custom rule-based reachability under
+constraints, "which calls satisfy property X"). So we lead with the graph and
+treat the solver as an additive layer that reuses a facts artifact we emit
+early. This also de-risks the project: the user-visible wins (points 1-4) land
+without ever depending on a Prolog/Z3 runtime.
+
+## 3. Source grounding
+
+- **Issue #39** — the five integration points and the "what's missing" table.
+- **chiasmus** `~/src/chiasmus/src/`, the design we model on:
+  - `graph/types.ts` — the `CodeGraph` data model: flat `defines` /
+    `calls` / `imports` / `exports` / `contains` fact tuples. Language-agnostic,
+    translates directly to Datalog/Prolog.
+  - `graph/parser.ts` — tree-sitter invocation, per-language grammar loading.
+  - `graph/extractor.ts` — AST → graph facts, per-language walks, two-pass
+    (collect calls, then resolve).
+  - `graph/resolve-calls.ts` + `type-env.ts` + `tsconfig-aliases.ts` +
+    `suffix-index.ts` — cross-file import resolution and qualified-name
+    resolution (receiver chains → `Class.method`).
+  - `graph/native-analyses.ts` — the BFS/DFS/SCC analyses (the part we port).
+  - `graph/facts.ts` — `graphToProlog` and the fact/rule schema (for the
+    optional solver layer; quoted verbatim in §5 Phase 5).
+  - `graph/cache.ts` + `diff.ts` — per-file-hash caching and snapshot diff.
+  - `graph/adapter-registry.ts` — how a new language plugs in.
+  - `solvers/prolog-solver.ts` — SWI-Prolog WASM, the reference for the solver.
+
+## 4. How it maps onto ATLAS today
+
+| #39 point | ATLAS today | What changes |
+|---|---|---|
+| precomputed call graph | none; ad-hoc tree-sitter walks | new cached `CodeGraph` substrate (Phase 0) |
+| 1. candidate scoring veto | `structural_score` direct-identifier name check (`v3-service/main.py`) | resolve calls against graph; reject calls with no reachable definition (Phase 1) |
+| 3. repair call-chain context | `call_chain_context` 1-hop callers/callees (`v3-service/main.py`) | multi-hop reachability slice + path witnesses (Phase 2) |
+| 4. context auto-injection | `symbol_index` name-match snippets (`proxy/symbol_index.go` + v3-service) | inject the symbol's graph neighborhood / impact set (Phase 3) |
+| 2. tier classification | cyclomatic complexity, shipped (`/internal/cyclomatic_complexity`) | optional graph fan-in/out enrichment (Phase 4, low priority) |
+| ast_edit | friendly selectors, Python + HTML (shipped) | unchanged; raw-query routing is a separate small follow-up |
+
+Tree-sitter is already a v3-service dependency (`tree_sitter`,
+`tree_sitter_python`, `tree_sitter_html`), and v3-service already extracts
+Python defs/calls in `symbol_index`, `structural_score`, and
+`call_chain_context`. So the graph substrate extends code that already exists
+rather than greenfield. Internal endpoints already live in v3-service
+(`/internal/symbol_index`, `/internal/ast_edit`, `/internal/cyclomatic_complexity`),
+so a `/internal/call_graph` endpoint is the natural home.
+
+## 5. Decisions
+
+Two decisions were confirmed up front (same shape as the wavelet port for #120).
+
+**Reuse strategy: port the graph engine to Python.** Model `v3-service/graph/`
+on chiasmus's `src/graph/`: reuse the `CodeGraph` fact model, the native
+analyses (BFS/SCC/dead-code/entry-points), import resolution via a suffix index,
+and the per-file-hash cache, and reuse the Prolog fact schema verbatim.
+Reimplement the tree-sitter extraction in Python, extending what v3-service
+already does. This keeps the graph in-process, reuses the existing tree-sitter
+setup, adds no new runtime, and matches the #120 precedent. The cost is that
+this is a bigger port than the wavelet engine, since the extractor and resolver
+are substantial, so Phase 0 is scoped tightly to the analyses the four
+integration points need rather than all 16 chiasmus analyses, and to Python
+first. The alternatives considered and set aside were a Node sidecar running
+chiasmus directly (maximal reuse but a new runtime and a network hop on the
+latency budget) and a from-scratch minimal reimplementation (less code but
+reinvents resolution and caching chiasmus already solved). Everything downstream
+of Phase 0 is agnostic to this choice, since it consumes the same in-process
+graph-query contract.
+
+**Solver scope: native first, solver as an optional Phase 5.** Points 1-4 are
+delivered with native graph traversal. Prolog facts are emitted early so the
+solver can be added later without re-plumbing, and the solver itself lands only
+as an additive final layer for custom rule queries the native layer can't
+express. This keeps the core dependency-free and matches how chiasmus itself
+works (§2).
+
+## 6. Phased plan
+
+Each phase is independently shippable and behind a feature flag, default off
+(`ATLAS_CALL_GRAPH=0`), strictly additive. No behavior change until enabled.
+
+### Phase 0 — Call-graph substrate — ✅ SHIPPED
+**Goal:** v3-service can build and cache a project call graph and answer native
+queries.
+
+- Ported into `v3-service/graph/`: `types.py` (CodeGraph fact model),
+  `extract.py` (tree-sitter Python extraction, modeled on chiasmus `walkPython`),
+  `analyses.py` (callers / callees / reachability / path / impact / cycles /
+  dead-code / entry-points, native O(V+E) with iterative Tarjan SCC), `resolve.py`
+  (Python import resolution, the suffix-index analogue), `facts.py`
+  (`graph_to_prolog` for the Phase 5 solver, emitted early), `cache.py`
+  (per-file-hash LRU for incremental recompute), `flags.py` (`ATLAS_CALL_GRAPH`).
+- `build_graph(file_map)` builds and caches the project graph; `run_analysis`
+  dispatches the native analyses.
+- Internal contract shipped: `POST /internal/call_graph` taking
+  `{file_map, analysis, target/from/to/entry_points}`, gated by
+  `ATLAS_CALL_GRAPH` (returns `ok=false` when off). Dockerfile copies the
+  package; CI installs the tree-sitter grammars and runs the suite.
+- **Golden parity** against chiasmus's own `native-analyses.ts` (captured via
+  `npx tsx`): callers, callees, reachability both directions, path sequence,
+  impact in BFS order, dead-code, and a self-recursion cycle all match. One
+  port fix surfaced from it — `impact` now returns BFS discovery order to match
+  chiasmus (Python sets aren't insertion-ordered).
+- Tests: `tests/v3-service/test_graph_{analyses,extract,support}.py`, 39 tests.
+- **Exit (met):** v3-service answers callers / reachability / path over a real
+  project, cross-file imports resolved, behind the flag. No pipeline change yet.
+
+### Phase 1 — Deepen the structural veto (#39 point 1) — ✅ SHIPPED
+**Goal:** reject candidates whose calls don't resolve to reachable definitions,
+not just whose imports survive.
+
+- `graph/resolve_calls.py`: `unresolved_calls` resolves the candidate's
+  **direct-identifier** calls (attribute/method calls stay out of scope, as in
+  the shipped veto) against the import graph. A call resolves if it is defined
+  locally, a builtin, an imported name, or supplied by a wildcard import whose
+  module's **actual exports** are resolved via the graph. The deepening
+  (strict policy, chosen): a bare call to a name that merely exists in some
+  *unimported* project file is now flagged, where the shipped veto accepted it.
+- Conservative guards: an unresolvable wildcard (stdlib / third-party) makes the
+  result `lenient` and flags nothing; attribute calls are never flagged.
+- Wired into the pipeline `run` after the existing structural veto, gated by
+  `ATLAS_CALL_GRAPH`, additive, and it never empties the candidate set (a
+  fully-failing set falls through to phase-3 repair). Off → unchanged behavior.
+- Tests: `tests/v3-service/test_graph_resolve_calls.py` (8) — local/builtin/
+  import resolution, the strict unimported-symbol flag, wildcard-to-exports,
+  stdlib-wildcard leniency, attribute calls never flagged.
+- **Exit (met):** the veto catches a bare call to an unimported project symbol
+  (a real NameError) that the shipped shape check let through, while staying
+  lenient on opaque wildcards and attribute calls.
+
+### Phase 2 — Multi-hop repair context (#39 point 3)
+**Goal:** give the repair model the real call chain, not 1-hop neighbors.
+
+- Replace `call_chain_context`'s immediate callers/callees with a reachability
+  slice: the path(s) from entry points to the failing function, its transitive
+  callers (impact set), and its callees, bounded for token budget.
+- **Exit:** repair context for a deep failure includes the actual call path, not
+  just direct neighbors.
+
+### Phase 3 — Graph-scoped context injection (#39 point 4)
+**Goal:** when the user names a symbol, inject its graph neighborhood.
+
+- Replace the name-match snippets in `symbol_index` with a graph slice: the
+  named symbol plus its callers, callees, and impact set, resolved across files.
+- **Exit:** naming a symbol pulls in the structurally related code, measured by
+  fewer model exploration turns on L6 tasks.
+
+### Phase 4 — Tier enrichment (#39 point 2, low priority)
+**Goal:** optional graph signals in tier classification.
+
+- Cyclomatic complexity already ships. Optionally fold in fan-in/fan-out or
+  reachability breadth as a secondary tier signal. Skip if it doesn't move tier
+  accuracy.
+
+### Phase 5 — Optional solver layer (the literal "+ solver")
+**Goal:** custom rule-based queries native traversal can't express.
+
+- Emit Prolog facts from the graph using chiasmus's exact schema
+  (`defines/4`, `calls/2`, `calls_qn/3`, `imports/3`, `imports_resolved/3`,
+  `exports/2`, `contains/2`, `entry_point/1`, plus the `reaches`/`path`/
+  `func_reaches`/`dead` rules from `facts.ts`). Ship the facts artifact early
+  (cheap) so the solver can be added without re-plumbing.
+- Add a SWI-Prolog (Datalog-style) backend for transitive-closure queries under
+  custom constraints. Decide Prolog vs Datalog vs Z3 here; for call-graph
+  reachability, Prolog/Datalog fits and chiasmus uses SWI-Prolog WASM. As a
+  Python service this likely means a `pyswip`/subprocess SWI binding or a small
+  Datalog engine; a Node sidecar reusing chiasmus's solver is the alternative.
+- **Exit:** a custom reachability-under-constraints query the native layer can't
+  express returns a solver-verified answer. Strictly additive; native stays the
+  default path.
+
+### Phase 6 — Multi-language
+**Goal:** beyond Python.
+
+- Generalize extraction via an adapter pattern (chiasmus `adapter-registry.ts`).
+  Ship Python plus JS/TS first (well-supported grammars, biggest user base, per
+  #39), install the grammars in `v3-service/Dockerfile`, add cross-file
+  resolution per language (tsconfig aliases for TS, etc.).
+
+## 7. Risks / open questions
+
+- **Scope of the port.** chiasmus's extractor + resolver is substantial. Scope
+  Phase 0 to the analyses points 1-4 actually need, not all 16, and to Python
+  first. Resist porting communities/hubs/bridges until something needs them.
+- **Dynamic dispatch / metaprogramming.** Python `getattr`, runtime routes,
+  duck typing. Tree-sitter sees syntax, not runtime. Keep the veto conservative:
+  unresolved-due-to-dynamism is not a bug to reject on. chiasmus excludes methods
+  from reachability for exactly this reason (`native-analyses.ts` filters
+  `kind=method`).
+- **Latency.** Building a graph per request is too slow; the cache is essential.
+  Recompute only touched files on write. Bench before it lands in the proxy's
+  critical path (#39 explicitly flags the latency budget).
+- **Solver runtime.** A real Prolog/Z3 in the Python stack is a new heavy
+  dependency. Deferring it to Phase 5 and gating it keeps the core
+  dependency-free; revisit Node-sidecar-vs-Python-binding when it's actually
+  needed.
+- **Correctness of cross-file resolution in Python.** No tsconfig analogue;
+  resolution is import-statement + module-path based. Model on chiasmus's
+  suffix-index approach but expect Python-specific edge cases (relative imports,
+  `__init__.py` re-exports).
+
+## 8. First concrete step
+
+Phase 0, the substrate: port the `CodeGraph` model and the native analyses into
+`v3-service/graph/` (Python), extending the existing tree-sitter extraction,
+with a per-file-hash cache and a `/internal/call_graph` endpoint, all behind
+`ATLAS_CALL_GRAPH`. Confirm v3-service answers callers / reachability / path over
+a real project within the latency budget, with golden parity against
+`chiasmus_graph` on shared Python fixtures.

--- a/proxy/agent.go
+++ b/proxy/agent.go
@@ -150,6 +150,10 @@ func runAgentLoop(ctx *AgentContext, userMessage string) error {
 		if len(fileMap) > 0 {
 			if idx, ok := resolveProjectSymbols(ctx, fileMap, symbols); ok && len(idx.Matched) > 0 {
 				body := formatProjectContextMessage(idx.Matched)
+				// #39 Phase 3: append the call-graph neighborhood when v3-service
+				// returned it (ATLAS_CALL_GRAPH on). Empty string when absent, so
+				// flag-off behavior is unchanged.
+				body += formatGraphNeighborhood(idx.Graph)
 				if body != "" {
 					// Role MUST be "user" with a "[system note]:" prefix —
 					// Qwen3.5's Jinja template enforces "System message

--- a/proxy/symbol_index.go
+++ b/proxy/symbol_index.go
@@ -183,6 +183,17 @@ func walkPythonFiles(root string) map[string]string {
 	return result
 }
 
+// symbolGraphNode mirrors one entry of the v3-service symbol_index "graph"
+// field (issue #39 Phase 3): a matched symbol's call-graph neighborhood.
+// Present only when ATLAS_CALL_GRAPH is on; omitted otherwise.
+type symbolGraphNode struct {
+	Symbol    string   `json:"symbol"`
+	DefinedIn []string `json:"defined_in"`
+	Callers   []string `json:"callers"`
+	Callees   []string `json:"callees"`
+	Impact    []string `json:"impact"`
+}
+
 // symbolIndexResult mirrors the v3-service /internal/symbol_index response.
 type symbolIndexResult struct {
 	Matched []struct {
@@ -197,6 +208,7 @@ type symbolIndexResult struct {
 		Name   string `json:"name"`
 		Reason string `json:"reason"`
 	} `json:"skipped"`
+	Graph []symbolGraphNode `json:"graph"`
 }
 
 // resolveProjectSymbols POSTs to v3-service and returns the matched
@@ -275,5 +287,31 @@ func formatProjectContextMessage(matched []struct {
 		}
 		sb.WriteString("```\n\n")
 	}
+	return sb.String()
+}
+
+// formatGraphNeighborhood renders the call-graph neighborhood (callers /
+// callees) of the matched symbols (issue #39 Phase 3). Empty when no graph
+// data was returned (flag off, or no edges). Gives the model the structurally
+// related code without a read_file loop.
+func formatGraphNeighborhood(graph []symbolGraphNode) string {
+	if len(graph) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("## Call-graph neighborhood (structurally related symbols)\n\n")
+	for _, g := range graph {
+		sb.WriteString("- `")
+		sb.WriteString(g.Symbol)
+		sb.WriteString("`")
+		if len(g.Callers) > 0 {
+			sb.WriteString(" — called by: " + strings.Join(g.Callers, ", "))
+		}
+		if len(g.Callees) > 0 {
+			sb.WriteString("; calls: " + strings.Join(g.Callees, ", "))
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
 	return sb.String()
 }

--- a/proxy/symbol_index_test.go
+++ b/proxy/symbol_index_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -80,5 +82,35 @@ func TestExtractCandidateSymbolsCap(t *testing.T) {
 	got := extractCandidateSymbols(msg)
 	if len(got) != symbolMaxCandidates {
 		t.Errorf("got %d symbols, want %d (cap)", len(got), symbolMaxCandidates)
+	}
+}
+
+// #39 Phase 3: the proxy must parse and consume the v3-service "graph" field.
+func TestSymbolIndexResultParsesGraph(t *testing.T) {
+	raw := `{"matched":[{"name":"load","kind":"function","file":"svc.py","snippet":"def load(): ...","n_lines":1,"truncated":false}],` +
+		`"skipped":[],` +
+		`"graph":[{"symbol":"load","defined_in":["svc.py"],"callers":["main"],"callees":["clean"],"impact":["main"]}]}`
+	var r symbolIndexResult
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(r.Graph) != 1 || r.Graph[0].Symbol != "load" {
+		t.Fatalf("graph not parsed: %+v", r.Graph)
+	}
+	if r.Graph[0].Callers[0] != "main" || r.Graph[0].Callees[0] != "clean" {
+		t.Errorf("graph neighborhood wrong: %+v", r.Graph[0])
+	}
+}
+
+func TestFormatGraphNeighborhood(t *testing.T) {
+	if formatGraphNeighborhood(nil) != "" {
+		t.Error("empty graph should format to empty string")
+	}
+	out := formatGraphNeighborhood([]symbolGraphNode{
+		{Symbol: "load", Callers: []string{"main"}, Callees: []string{"clean"}},
+	})
+	if !strings.Contains(out, "load") || !strings.Contains(out, "called by: main") ||
+		!strings.Contains(out, "calls: clean") {
+		t.Errorf("unexpected format: %q", out)
 	}
 }

--- a/tests/v3-service/test_graph_analyses.py
+++ b/tests/v3-service/test_graph_analyses.py
@@ -1,0 +1,159 @@
+"""Conformance suite for the native call-graph analyses (issue #39, Phase 0).
+
+Includes a golden-parity test whose expected values were captured by running
+chiasmus's own `src/graph/native-analyses.ts` (the code this is ported from) on
+the identical graph via `npx tsx`. Divergence flags a behavioral fork.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+from graph.types import (  # noqa: E402
+    CallsFact, CodeGraph, DefinesFact, ExportsFact,
+)
+from graph import analyses  # noqa: E402
+
+
+def _graph():
+    # Same graph the chiasmus golden was captured on: main->helper->leaf, an
+    # orphan, and a self-recursive function.
+    return CodeGraph(
+        defines=[
+            DefinesFact("a.py", "main", "function", 1),
+            DefinesFact("a.py", "helper", "function", 2),
+            DefinesFact("a.py", "leaf", "function", 3),
+            DefinesFact("a.py", "orphan", "function", 4),
+            DefinesFact("a.py", "recurse", "function", 5),
+        ],
+        calls=[
+            CallsFact("main", "helper"),
+            CallsFact("helper", "leaf"),
+            CallsFact("recurse", "recurse"),
+        ],
+        exports=[ExportsFact("a.py", "main")],
+    )
+
+
+class TestGoldenParity:
+    """Expected values captured from chiasmus native-analyses.ts via npx tsx."""
+
+    def test_matches_chiasmus(self):
+        g = _graph()
+        assert analyses.callers(g, "leaf") == ["helper"]
+        assert analyses.callees(g, "main") == ["helper"]
+        assert analyses.reachability(g, "main", "leaf") is True
+        assert analyses.reachability(g, "leaf", "main") is False
+        # chiasmus formats path as the Prolog-list string "[main,helper,leaf]";
+        # the node sequence is identical.
+        assert analyses.path(g, "main", "leaf") == ["main", "helper", "leaf"]
+        # Order matters: chiasmus emits impact in BFS discovery order.
+        assert analyses.impact(g, "leaf") == ["helper", "main"]
+        assert analyses.dead_code(g, ["main"]) == ["orphan"]
+        assert analyses.cycles(g) == ["recurse"]
+
+
+class TestDeterminism:
+    """First-seen edge order must drive path tie-breaks and impact order, matching
+    chiasmus (golden captured via npx tsx). Guards against Python set reordering."""
+
+    def test_path_tiebreak_first_seen_edge(self):
+        # adj[A] first-seen = [zebra, alpha]; two equal-length paths to T.
+        g = CodeGraph(calls=[
+            CallsFact("A", "zebra"), CallsFact("A", "alpha"),
+            CallsFact("zebra", "T"), CallsFact("alpha", "T"),
+        ])
+        # chiasmus golden: path goes through zebra (first-seen out of A).
+        assert analyses.path(g, "A", "T") == ["A", "zebra", "T"]
+
+    def test_impact_bfs_discovery_order(self):
+        # rev[T] first-seen = [B, C]; then D (via B), E (via C).
+        g = CodeGraph(calls=[
+            CallsFact("B", "T"), CallsFact("C", "T"),
+            CallsFact("D", "B"), CallsFact("E", "C"),
+        ])
+        assert analyses.impact(g, "T") == ["B", "C", "D", "E"]
+
+
+class TestReachability:
+    def test_self_pair_needs_self_edge(self):
+        g = CodeGraph(
+            defines=[DefinesFact("a.py", "f", "function", 1)],
+            calls=[CallsFact("f", "f")],
+        )
+        assert analyses.reachability(g, "f", "f") is True
+        g2 = CodeGraph(
+            defines=[DefinesFact("a.py", "f", "function", 1),
+                     DefinesFact("a.py", "g", "function", 2)],
+            calls=[CallsFact("f", "g")],
+        )
+        assert analyses.reachability(g2, "f", "f") is False
+
+    def test_unknown_nodes(self):
+        g = _graph()
+        assert analyses.reachability(g, "nope", "leaf") is False
+        assert analyses.path(g, "main", "nope") == []
+
+
+class TestCycles:
+    def test_multi_node_cycle(self):
+        g = CodeGraph(
+            defines=[DefinesFact("a.py", n, "function", i) for i, n in enumerate("abc")],
+            calls=[CallsFact("a", "b"), CallsFact("b", "c"), CallsFact("c", "a")],
+        )
+        assert set(analyses.cycles(g)) == {"a", "b", "c"}
+
+    def test_no_cycle(self):
+        g = _graph()
+        g.calls = [CallsFact("main", "helper"), CallsFact("helper", "leaf")]
+        assert analyses.cycles(g) == []
+
+    def test_methods_excluded_from_cycles(self):
+        # Two methods named the same across classes must not produce a phantom
+        # cycle. m -> m where m is kind=method is dropped.
+        g = CodeGraph(
+            defines=[DefinesFact("a.py", "m", "method", 1)],
+            calls=[CallsFact("m", "m")],
+        )
+        assert analyses.cycles(g) == []
+
+
+class TestImpactAndDead:
+    def test_impact_transitive(self):
+        g = _graph()
+        # leaf's impact is everything that can reach it: helper, main.
+        assert analyses.impact(g, "leaf") == ["helper", "main"]
+        assert analyses.impact(g, "main") == []  # nothing calls main
+
+    def test_dead_code_default_entrypoints(self):
+        g = _graph()
+        # Default entry points = exports (main). orphan + recurse + helper + leaf
+        # are not exported; helper/leaf are called, recurse calls itself.
+        dead = analyses.dead_code(g)
+        assert "orphan" in dead
+        assert "main" not in dead  # it's an export/entry
+
+    def test_dead_code_excludes_methods(self):
+        g = CodeGraph(defines=[DefinesFact("a.py", "m", "method", 1)], calls=[])
+        assert analyses.dead_code(g) == []
+
+
+class TestEntryPoints:
+    def test_zero_in_degree_exports(self):
+        g = _graph()
+        # main (exported, zero in-degree) is an entry point.
+        assert "main" in analyses.detect_entry_points(g)
+
+
+class TestDispatch:
+    def test_run_analysis_routes(self):
+        g = _graph()
+        assert analyses.run_analysis(g, "callers", target="leaf") == ["helper"]
+        assert analyses.run_analysis(g, "reachability", frm="main", to="leaf") is True
+        assert analyses.run_analysis(g, "cycles") == ["recurse"]
+
+    def test_unknown_analysis_raises(self):
+        import pytest
+        with pytest.raises(ValueError):
+            analyses.run_analysis(_graph(), "nonsense")

--- a/tests/v3-service/test_graph_context.py
+++ b/tests/v3-service/test_graph_context.py
@@ -1,0 +1,69 @@
+"""Tests for graph-backed repair context (Phase 2, #39 pt 3) and symbol
+neighborhood (Phase 3, #39 pt 4)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+import graph  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not graph.extraction_available(),
+                                reason="tree-sitter Python grammar not installed")
+
+# main -> service.run -> load -> read; process is a sibling consumer of load.
+PROJECT = {
+    "app.py": (
+        "from svc import load, read, process\n\n"
+        "def main():\n"
+        "    rows = load(read())\n"
+        "    return process(rows)\n"
+    ),
+    "svc.py": (
+        "def read():\n    return []\n\n"
+        "def load(data):\n    return clean(data)\n\n"
+        "def clean(data):\n    return data\n\n"
+        "def process(rows):\n    return rows\n"
+    ),
+}
+
+
+class TestRepairContext:
+    def test_includes_callers_callees_and_path(self):
+        ctx = graph.repair_context(PROJECT, "load")
+        assert "load" in ctx
+        assert "Defined in" in ctx
+        # main calls load -> main is a direct caller
+        assert "main" in ctx
+        # load calls clean -> clean is a callee
+        assert "clean" in ctx
+        # path from an entry point (main) to load
+        assert "Call path" in ctx and "→" in ctx
+
+    def test_empty_when_function_absent(self):
+        assert graph.repair_context(PROJECT, "does_not_exist") == ""
+
+    def test_empty_when_no_python(self):
+        assert graph.repair_context({"a.md": "x"}, "load") == ""
+
+    def test_leaf_function(self):
+        ctx = graph.repair_context(PROJECT, "clean")
+        assert "leaf" in ctx  # clean calls nothing
+
+
+class TestSymbolNeighborhood:
+    def test_callers_callees_impact(self):
+        nb = graph.symbol_neighborhood(PROJECT, "load")
+        assert nb["symbol"] == "load"
+        assert "svc.py" in nb["defined_in"]
+        assert "main" in nb["callers"]
+        assert "clean" in nb["callees"]
+        # impact = transitive callers; main reaches load
+        assert "main" in nb["impact"]
+
+    def test_unknown_symbol_empty(self):
+        nb = graph.symbol_neighborhood(PROJECT, "nope")
+        assert nb["callers"] == [] and nb["callees"] == [] and nb["impact"] == []
+        assert nb["defined_in"] == []

--- a/tests/v3-service/test_graph_context.py
+++ b/tests/v3-service/test_graph_context.py
@@ -67,3 +67,11 @@ class TestSymbolNeighborhood:
         nb = graph.symbol_neighborhood(PROJECT, "nope")
         assert nb["callers"] == [] and nb["callees"] == [] and nb["impact"] == []
         assert nb["defined_in"] == []
+
+    def test_prebuilt_graph_reused(self):
+        # Passing a prebuilt graph avoids rebuilding per symbol and gives the
+        # same result as building internally.
+        g = graph.build_graph(PROJECT)
+        a = graph.symbol_neighborhood(PROJECT, "load", graph=g)
+        b = graph.symbol_neighborhood(PROJECT, "load")
+        assert a == b

--- a/tests/v3-service/test_graph_extract.py
+++ b/tests/v3-service/test_graph_extract.py
@@ -1,0 +1,174 @@
+"""Tests for tree-sitter Python extraction into CodeGraph (issue #39, Phase 0).
+
+Skipped cleanly when the tree-sitter grammar isn't installed; in CI it is.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+from graph import extract_file, extraction_available, is_python  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not extraction_available(),
+                                reason="tree-sitter Python grammar not installed")
+
+SAMPLE = """import os
+from pathlib import Path
+from .utils import helper as h
+
+
+class Service:
+    def __init__(self, config):
+        self.config = config
+
+    def run(self, data):
+        return self.process(data)
+
+    def process(self, data):
+        return clean(data)
+
+
+def clean(data):
+    return [d for d in data if d]
+
+
+def main():
+    s = Service({})
+    return s.run([1, 2, 3])
+"""
+
+
+def _names(facts):
+    return [f.name for f in facts]
+
+
+class TestExtract:
+    def test_defines_functions_classes_methods(self):
+        g = extract_file("svc.py", SAMPLE)
+        by_name = {d.name: d for d in g.defines}
+        assert by_name["Service"].kind == "class"
+        assert by_name["clean"].kind == "function"
+        assert by_name["main"].kind == "function"
+        # methods inside the class are kind=method
+        assert by_name["run"].kind == "method"
+        assert by_name["process"].kind == "method"
+
+    def test_contains_links_methods_to_class(self):
+        g = extract_file("svc.py", SAMPLE)
+        pairs = {(c.parent, c.child) for c in g.contains}
+        assert ("Service", "run") in pairs
+        assert ("Service", "process") in pairs
+
+    def test_calls_bare_and_method(self):
+        g = extract_file("svc.py", SAMPLE)
+        calls = {(c.caller, c.callee) for c in g.calls}
+        # method-call receiver dropped to the bare method name (matches chiasmus)
+        assert ("run", "process") in calls       # self.process(...) -> process
+        assert ("process", "clean") in calls      # clean(...)
+        assert ("main", "run") in calls           # s.run(...) -> run
+
+    def test_signatures_captured(self):
+        g = extract_file("svc.py", SAMPLE)
+        run = next(d for d in g.defines if d.name == "run")
+        assert "self" in run.signature and "data" in run.signature
+
+    def test_imports(self):
+        g = extract_file("svc.py", SAMPLE)
+        names = _names(g.imports)
+        assert "os" in names
+        assert "Path" in names
+        assert "h" in names  # aliased: helper as h
+
+    def test_exports_are_top_level_defs(self):
+        g = extract_file("svc.py", SAMPLE)
+        names = _names(g.exports)
+        assert "Service" in names
+        assert "clean" in names
+        assert "main" in names
+        # methods are not exports
+        assert "run" not in names
+
+    def test_decorated_function(self):
+        g = extract_file("d.py", "@app.route('/x')\ndef handler():\n    return 1\n")
+        assert any(d.name == "handler" and d.kind == "function" for d in g.defines)
+
+    def test_empty_and_nonpython(self):
+        assert extract_file("a.py", "").defines == []
+        assert is_python("x.py") and not is_python("x.md")
+
+
+# Golden parity against chiasmus's own extractGraph (src/graph/extractor.ts),
+# captured via `npx tsx` on this exact fixture. Locks the extraction port to the
+# reference. Exports are intentionally excluded: chiasmus emits none for Python
+# (no export syntax); ATLAS synthesizes them from top-level defs for entry-point
+# defaulting, so that field is an intentional divergence, not a parity target.
+_GOLDEN_FIXTURE = """import os
+import sys as system
+from pathlib import Path
+from .helpers import clean, validate as v
+
+
+class Pipeline:
+    def __init__(self, config):
+        self.config = config
+
+    def run(self, data):
+        rows = self.load(data)
+        return self.process(rows)
+
+    def load(self, data):
+        return clean(data)
+
+    @staticmethod
+    def process(rows):
+        return [transform(r) for r in rows]
+
+
+def transform(row):
+    return validate_row(row)
+
+
+def validate_row(row):
+    return v(row)
+
+
+def main():
+    p = Pipeline({})
+    return p.run(read_input())
+
+
+def read_input():
+    return []
+"""
+
+_GOLDEN = {
+    "defines": [["Pipeline", "class", 7], ["__init__", "method", 8],
+                ["load", "method", 15], ["main", "function", 31],
+                ["process", "method", 19], ["read_input", "function", 36],
+                ["run", "method", 11], ["transform", "function", 23],
+                ["validate_row", "function", 27]],
+    "calls": [["load", "clean"], ["main", "Pipeline"], ["main", "read_input"],
+              ["main", "run"], ["process", "transform"], ["run", "load"],
+              ["run", "process"], ["transform", "validate_row"],
+              ["validate_row", "v"]],
+    "imports": [["Path", "pathlib"], ["clean", ".helpers"], ["os", "os"],
+                ["system", "sys"], ["v", ".helpers"]],
+    "contains": [["Pipeline", "__init__"], ["Pipeline", "load"],
+                 ["Pipeline", "process"], ["Pipeline", "run"]],
+}
+
+
+class TestGoldenExtractionParity:
+    def test_matches_chiasmus_extractor(self):
+        g = extract_file("pipe.py", _GOLDEN_FIXTURE)
+        got = {
+            "defines": sorted([[d.name, d.kind, d.line] for d in g.defines]),
+            "calls": sorted([[c.caller, c.callee] for c in g.calls]),
+            "imports": sorted([[i.name, i.source] for i in g.imports]),
+            "contains": sorted([[c.parent, c.child] for c in g.contains]),
+        }
+        for key, expected in _GOLDEN.items():
+            assert got[key] == sorted(expected), f"{key} diverged from chiasmus"

--- a/tests/v3-service/test_graph_multilang.py
+++ b/tests/v3-service/test_graph_multilang.py
@@ -1,0 +1,88 @@
+"""JavaScript extraction (issue #39, Phase 6) with golden parity against
+chiasmus's own extractor, captured via npx tsx on the same fixture."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+import graph  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not graph.js_available(),
+                                reason="tree-sitter JavaScript grammar not installed")
+
+JS_FIXTURE = """import { clean } from "./helpers.js";
+import defaultExport from "./def.js";
+
+export function main() {
+  const p = new Pipeline();
+  return p.run(read());
+}
+
+class Pipeline {
+  run(data) {
+    return this.load(data);
+  }
+  load(data) {
+    return clean(data);
+  }
+}
+
+const read = () => {
+  return [];
+};
+
+function helper() {
+  return transform();
+}
+"""
+
+GOLDEN = {
+    "defines": [["Pipeline", "class"], ["helper", "function"], ["load", "method"],
+                ["main", "function"], ["read", "function"], ["run", "method"]],
+    "calls": [["helper", "transform"], ["load", "clean"], ["main", "read"],
+              ["main", "run"], ["run", "load"]],
+    "imports": [["clean", "./helpers.js"], ["defaultExport", "./def.js"]],
+}
+
+
+class TestJsGoldenParity:
+    def test_matches_chiasmus(self):
+        g = graph.extract_file("pipe.js", JS_FIXTURE)
+        got = {
+            "defines": sorted([[d.name, d.kind] for d in g.defines]),
+            "calls": sorted([[c.caller, c.callee] for c in g.calls]),
+            "imports": sorted([[i.name, i.source] for i in g.imports]),
+        }
+        for key, expected in GOLDEN.items():
+            assert got[key] == sorted(expected), f"{key} diverged from chiasmus"
+
+    def test_new_expression_not_a_call(self):
+        # `new Pipeline()` must not appear as a call edge.
+        g = graph.extract_file("pipe.js", JS_FIXTURE)
+        assert all(c.callee != "Pipeline" for c in g.calls)
+
+    def test_method_contains(self):
+        g = graph.extract_file("pipe.js", JS_FIXTURE)
+        pairs = {(c.parent, c.child) for c in g.contains}
+        assert ("Pipeline", "run") in pairs and ("Pipeline", "load") in pairs
+
+
+class TestMixedProject:
+    def test_python_and_js_in_one_graph(self):
+        files = {
+            "a.py": "def py_fn():\n    return 1\n",
+            "b.js": "function js_fn() {\n  return helper();\n}\n",
+        }
+        g = graph.build_graph(files)
+        names = {d.name for d in g.defines}
+        assert {"py_fn", "js_fn"} <= names
+        # analyses work across the merged multi-language graph
+        assert graph.callees(g, "js_fn") == ["helper"]
+
+    def test_is_supported(self):
+        assert graph.is_js("x.js") and graph.is_js("x.mjs")
+        assert graph.is_supported("x.py") and graph.is_supported("x.jsx")
+        assert not graph.is_supported("x.md")

--- a/tests/v3-service/test_graph_resolve_calls.py
+++ b/tests/v3-service/test_graph_resolve_calls.py
@@ -1,0 +1,140 @@
+"""Tests for graph-backed call resolution (issue #39, Phase 1).
+
+This is the deepened structural-veto core: resolve a candidate's direct calls
+against the import graph rather than accepting any project symbol.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+import graph  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not graph.extraction_available(),
+                                reason="tree-sitter Python grammar not installed")
+
+
+def _unresolved(cand_code, project=None, strict=True):
+    r = graph.unresolved_calls("cand.py", cand_code, project or {}, strict=strict)
+    assert r["ok"]
+    return r["unresolved"], r
+
+
+class TestDirectCallNames:
+    def test_identifier_calls_only(self):
+        code = "def f():\n    g()\n    obj.method()\n    h(x)\n"
+        names = graph.direct_call_names(code)
+        assert "g" in names and "h" in names
+        assert "method" not in names  # attribute call skipped
+
+
+class TestResolution:
+    def test_local_and_builtin_resolve(self):
+        code = "def helper():\n    return 1\n\ndef main():\n    helper()\n    print(len([]))\n"
+        unresolved, _ = _unresolved(code)
+        assert unresolved == []
+
+    def test_from_import_resolves(self):
+        code = "from pkg.util import helper\n\ndef main():\n    return helper()\n"
+        unresolved, _ = _unresolved(code, {"pkg/util.py": "def helper():\n    return 1\n"})
+        assert unresolved == []
+
+    def test_bare_unimported_project_symbol_flagged_in_strict(self):
+        # helper exists in the project but is NOT imported by the candidate.
+        # Strict mode flags it (a real NameError); this is the deepening over
+        # the shipped veto, which accepted it via the project-symbol set.
+        code = "def main():\n    return helper()\n"
+        project = {"other.py": "def helper():\n    return 1\n"}
+        strict_unres, _ = _unresolved(code, project, strict=True)
+        assert "helper" in strict_unres
+        # Non-strict restores the old lenient behavior.
+        lax_unres, _ = _unresolved(code, project, strict=False)
+        assert lax_unres == []
+
+    def test_wildcard_resolved_to_module_exports(self):
+        # `from mod import *` where mod defines `helper` -> helper resolves;
+        # an unknown name still flags (we know mod's actual exports).
+        code = "from pkg.mod import *\n\ndef main():\n    helper()\n    missing()\n"
+        project = {"pkg/mod.py": "def helper():\n    return 1\n"}
+        unresolved, r = _unresolved(code, project, strict=True)
+        assert r["lenient"] is False
+        assert "helper" not in unresolved
+        assert "missing" in unresolved
+
+    def test_wildcard_unresolved_module_is_lenient(self):
+        # `from os import *` (stdlib, no in-batch file) -> can't know exports,
+        # so nothing is flagged.
+        code = "from os import *\n\ndef main():\n    getcwd()\n    whatever()\n"
+        unresolved, r = _unresolved(code, {}, strict=True)
+        assert r["lenient"] is True
+        assert unresolved == []
+
+    def test_attribute_calls_never_flagged(self):
+        # os.path.join() -> attribute call, out of scope, must not be flagged
+        # even though `join` is neither local nor imported.
+        code = "import os\n\ndef main():\n    return os.path.join('a', 'b')\n"
+        unresolved, _ = _unresolved(code, {})
+        assert unresolved == []
+
+    def test_unparseable_candidate(self):
+        # extraction yields no calls; nothing to flag.
+        unresolved, r = _unresolved("def (:\n  broken")
+        assert unresolved == []
+
+
+class TestNoFalsePositives:
+    """Names bound by means other than def/class must not be flagged."""
+
+    def test_assigned_callable(self):
+        # x = lambda ...; x()  — x is an assignment target, not a def.
+        unresolved, _ = _unresolved("def m():\n    x = lambda: 1\n    return x()\n")
+        assert unresolved == []
+
+    def test_module_level_assigned_callable(self):
+        code = "make = something\nhandler = make()\n\ndef m():\n    return handler()\n"
+        # `something` is a bare name read (not bound) — but it's not a *call*
+        # here, so it isn't in scope for the veto; handler/make are assigned.
+        unresolved, _ = _unresolved(code)
+        assert "handler" not in unresolved and "make" not in unresolved
+
+    def test_function_parameter_callback(self):
+        # def run(cb): return cb()  — cb is a parameter.
+        unresolved, _ = _unresolved("def run(cb):\n    return cb()\n")
+        assert unresolved == []
+
+    def test_higher_order(self):
+        unresolved, _ = _unresolved("def apply(fn, x):\n    return fn(x)\n")
+        assert unresolved == []
+
+    def test_loop_and_with_and_walrus_targets(self):
+        code = (
+            "def m(items):\n"
+            "    for f in items:\n"
+            "        f()\n"
+            "    with open('x') as fh:\n"
+            "        fh()\n"
+            "    if (g := items[0]):\n"
+            "        g()\n"
+        )
+        unresolved, _ = _unresolved(code)
+        assert unresolved == []
+
+    def test_comprehension_target(self):
+        unresolved, _ = _unresolved("def m(items):\n    return [f() for f in items]\n")
+        assert unresolved == []
+
+    def test_dotted_import_binds_top_package_only(self):
+        # `import a.b.c` binds `a`; a bare `c()` is NOT bound and should flag,
+        # while `a` (used as a.b.c.x attribute) is fine. Confirms first-segment
+        # binding, not last.
+        unresolved, _ = _unresolved("import xml.etree.ElementTree\n\ndef m():\n    ElementTree()\n")
+        assert "ElementTree" in unresolved
+
+    def test_still_flags_genuinely_unbound(self):
+        # Regression guard: the deepening still works after the FP fix.
+        unresolved, _ = _unresolved("def m():\n    return helper()\n",
+                                    {"other.py": "def helper():\n    return 1\n"})
+        assert "helper" in unresolved

--- a/tests/v3-service/test_graph_solver.py
+++ b/tests/v3-service/test_graph_solver.py
@@ -1,0 +1,81 @@
+"""Tests for the fan-in/out complexity signal (Phase 4) and the in-process
+Datalog solver layer (Phase 5)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+from graph.types import CodeGraph, CallsFact, DefinesFact  # noqa: E402
+from graph import analyses  # noqa: E402
+from graph.datalog import Datalog, Var, reachable_pairs, solver_reaches  # noqa: E402
+
+
+def _g():
+    # main -> helper -> leaf ; main -> util ; recurse -> recurse (self-loop)
+    return CodeGraph(
+        defines=[DefinesFact("a.py", n, "function", i)
+                 for i, n in enumerate(["main", "helper", "leaf", "util", "recurse"])],
+        calls=[
+            CallsFact("main", "helper"), CallsFact("helper", "leaf"),
+            CallsFact("main", "util"), CallsFact("recurse", "recurse"),
+        ],
+    )
+
+
+class TestComplexity:
+    def test_fan_in_out(self):
+        c = analyses.complexity(_g())
+        assert c["per_node"]["main"]["fan_out"] == 2   # helper, util
+        assert c["per_node"]["main"]["fan_in"] == 0
+        assert c["per_node"]["helper"]["fan_in"] == 1   # called by main
+        assert c["per_node"]["helper"]["fan_out"] == 1  # calls leaf
+        assert c["max_fan_out"] == 2
+        assert c["n_edges"] == 4
+
+    def test_dispatch(self):
+        assert analyses.run_analysis(_g(), "complexity")["max_fan_out"] == 2
+
+
+class TestDatalogEngine:
+    def test_generic_transitive_rule(self):
+        dl = Datalog()
+        for a, b in [("a", "b"), ("b", "c"), ("c", "d")]:
+            dl.add_fact("edge", a, b)
+        x, y, z = Var("X"), Var("Y"), Var("Z")
+        dl.add_rule(("tc", [x, y]), [("edge", [x, y])])
+        dl.add_rule(("tc", [x, y]), [("edge", [x, z]), ("tc", [z, y])])
+        dl.run()
+        pairs = {tuple(t) for t in dl.facts["tc"]}
+        assert ("a", "d") in pairs and ("a", "c") in pairs and ("b", "d") in pairs
+        assert ("d", "a") not in pairs
+
+    def test_query_bindings(self):
+        dl = Datalog()
+        dl.add_fact("calls", "main", "helper")
+        dl.add_fact("calls", "main", "util")
+        res = dl.query("calls", "main", Var("X"))
+        callees = sorted(b["X"] for b in res)
+        assert callees == ["helper", "util"]
+
+
+class TestSolverMatchesNative:
+    def test_closure_relation(self):
+        pairs = set(reachable_pairs(_g()))
+        assert ("main", "leaf") in pairs   # transitive
+        assert ("recurse", "recurse") in pairs  # self-loop
+        assert ("leaf", "main") not in pairs
+
+    def test_reaches_agrees_with_native_for_all_pairs(self):
+        g = _g()
+        names = sorted({d.name for d in g.defines}
+                       | {c.caller for c in g.calls} | {c.callee for c in g.calls})
+        for a in names:
+            for b in names:
+                assert solver_reaches(g, a, b) == analyses.reachability(g, a, b), (a, b)
+
+    def test_runaway_guard(self):
+        # A dense cycle still terminates under the iteration cap.
+        g = CodeGraph(calls=[CallsFact("a", "b"), CallsFact("b", "a")])
+        pairs = set(reachable_pairs(g))
+        assert ("a", "a") in pairs and ("b", "b") in pairs and ("a", "b") in pairs

--- a/tests/v3-service/test_graph_solver.py
+++ b/tests/v3-service/test_graph_solver.py
@@ -50,6 +50,16 @@ class TestDatalogEngine:
         assert ("a", "d") in pairs and ("a", "c") in pairs and ("b", "d") in pairs
         assert ("d", "a") not in pairs
 
+    def test_unsafe_rule_does_not_crash(self):
+        # A rule with a head variable not bound by the body is unsafe; run()
+        # must skip it rather than raise KeyError (public-API robustness).
+        dl = Datalog()
+        dl.add_fact("calls", "a", "b")
+        x, y = Var("X"), Var("Y")
+        dl.add_rule(("p", [x, y]), [("calls", [x])])  # Y unbound
+        dl.run()  # must not raise
+        assert dl.facts.get("p", set()) == set()
+
     def test_query_bindings(self):
         dl = Datalog()
         dl.add_fact("calls", "main", "helper")

--- a/tests/v3-service/test_graph_support.py
+++ b/tests/v3-service/test_graph_support.py
@@ -1,0 +1,179 @@
+"""Tests for graph support pieces: import resolution, Prolog facts, cache,
+flag, and the build_graph entry point (issue #39, Phase 0)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "v3-service"))
+
+import graph  # noqa: E402
+from graph.types import (  # noqa: E402
+    CodeGraph, DefinesFact, CallsFact, ImportsFact, ExportsFact, ContainsFact, FileNode,
+)
+from graph.facts import escape_atom, graph_to_prolog, BUILTIN_RULES  # noqa: E402
+from graph.resolve import resolve_imports, _module_name  # noqa: E402
+from graph.cache import FileGraphCache, file_hash  # noqa: E402
+from graph.flags import call_graph_enabled, ENV_VAR  # noqa: E402
+
+_HAS_TS = graph.extraction_available()
+
+
+class TestEscapeAtom:
+    def test_bare_atom(self):
+        assert escape_atom("main") == "main"
+        assert escape_atom("foo_bar2") == "foo_bar2"
+
+    def test_quoted(self):
+        assert escape_atom("Foo") == "'Foo'"
+        assert escape_atom("a/b.py") == "'a/b.py'"
+
+    def test_escapes_quote_and_backslash(self):
+        assert escape_atom("a'b") == "'a\\'b'"
+        assert escape_atom("a\\b") == "'a\\\\b'"
+
+
+class TestGraphToProlog:
+    def test_emits_facts_and_rules(self):
+        g = CodeGraph(
+            defines=[DefinesFact("a.py", "main", "function", 1)],
+            calls=[CallsFact("main", "helper")],
+            imports=[ImportsFact("a.py", "os", "os")],
+            exports=[ExportsFact("a.py", "main")],
+            contains=[ContainsFact("Svc", "run")],
+            files=[FileNode("a.py", "python", 10)],
+        )
+        prog = graph_to_prolog(g)
+        assert "defines('a.py', main, function, 1)." in prog
+        assert "calls(main, helper)." in prog
+        assert "imports('a.py', os, os)." in prog
+        assert "exports('a.py', main)." in prog
+        assert "contains('Svc', run)." in prog
+        assert "entry_point(main)." in prog
+        assert BUILTIN_RULES in prog  # the reaches/path/dead rules are appended
+
+    def test_resolved_imports_emitted(self):
+        g = CodeGraph(imports=[ImportsFact("a.py", "h", "pkg.util", resolved="pkg/util.py")])
+        prog = graph_to_prolog(g)
+        assert "imports_resolved('a.py', h, 'pkg/util.py')." in prog
+
+    def test_explicit_entry_points(self):
+        g = CodeGraph(exports=[ExportsFact("a.py", "main"), ExportsFact("a.py", "other")])
+        prog = graph_to_prolog(g, entry_points=["main"])
+        assert "entry_point(main)." in prog
+        assert "entry_point(other)." not in prog
+
+
+class TestModuleName:
+    def test_paths_to_modules(self):
+        assert _module_name("pkg/mod.py") == "pkg.mod"
+        assert _module_name("pkg/__init__.py") == "pkg"
+        assert _module_name("a/b/c.pyi") == "a.b.c"
+
+
+class TestResolveImports:
+    def test_exact_module(self):
+        # `from pkg.util import thing` -> source "pkg.util", which is a file.
+        g = CodeGraph(imports=[ImportsFact("app.py", "thing", "pkg.util")])
+        resolve_imports(g, ["app.py", "pkg/util.py"])
+        assert g.imports[0].resolved == "pkg/util.py"
+
+    def test_from_pkg_import_module(self):
+        # from pkg import mod  -> source "pkg", name "mod", pkg/mod.py exists
+        g = CodeGraph(imports=[ImportsFact("app.py", "mod", "pkg")])
+        resolve_imports(g, ["app.py", "pkg/mod.py", "pkg/__init__.py"])
+        assert g.imports[0].resolved == "pkg/mod.py"
+
+    def test_unresolved_external(self):
+        g = CodeGraph(imports=[ImportsFact("app.py", "os", "os")])
+        resolve_imports(g, ["app.py"])
+        assert g.imports[0].resolved is None
+
+    def test_ambiguous_suffix_not_resolved(self):
+        g = CodeGraph(imports=[ImportsFact("app.py", "x", "mod")])
+        resolve_imports(g, ["app.py", "a/mod.py", "b/mod.py"])
+        assert g.imports[0].resolved is None  # two candidates -> leave unresolved
+
+
+class TestCache:
+    def test_hit_on_same_content(self):
+        if not _HAS_TS:
+            pytest.skip("tree-sitter not installed")
+        c = FileGraphCache()
+        g1 = c.get_or_extract("a.py", "def f():\n    pass\n")
+        assert len(c) == 1
+        g2 = c.get_or_extract("a.py", "def f():\n    pass\n")
+        # Same content -> not re-parsed (cache stays size 1), but a distinct copy
+        # is returned so callers can't corrupt the cached object.
+        assert len(c) == 1
+        assert g1 is not g2
+        assert [d.name for d in g1.defines] == [d.name for d in g2.defines]
+
+    def test_resolve_does_not_corrupt_cache_across_batches(self):
+        if not _HAS_TS:
+            pytest.skip("tree-sitter not installed")
+        c = graph.FileGraphCache()
+        # Batch A includes the util module, so a.py's import resolves.
+        files_a = {"a.py": "from pkg.util import helper\n\ndef main():\n    return helper()\n",
+                   "pkg/util.py": "def helper():\n    return 1\n"}
+        ga = graph.build_graph(files_a, cache=c)
+        assert next(i for i in ga.imports if i.name == "helper").resolved == "pkg/util.py"
+        # Batch B is a.py alone. Its import must NOT still show the resolution
+        # from batch A (the bug: shared mutable ImportsFact on the cached graph).
+        gb = graph.build_graph({"a.py": files_a["a.py"]}, cache=c)
+        assert next(i for i in gb.imports if i.name == "helper").resolved is None
+
+    def test_miss_on_changed_content(self):
+        if not _HAS_TS:
+            pytest.skip("tree-sitter not installed")
+        c = FileGraphCache()
+        c.get_or_extract("a.py", "def f(): pass")
+        c.get_or_extract("a.py", "def g(): pass")
+        assert len(c) == 2  # different content -> separate entries
+
+    def test_hash_includes_path(self):
+        assert file_hash("a.py", "x") != file_hash("b.py", "x")
+        assert file_hash("a.py", "x") == file_hash("a.py", "x")
+
+    def test_lru_eviction(self):
+        if not _HAS_TS:
+            pytest.skip("tree-sitter not installed")
+        c = FileGraphCache(max_entries=2)
+        c.get_or_extract("a.py", "def a(): pass")
+        c.get_or_extract("b.py", "def b(): pass")
+        c.get_or_extract("c.py", "def c(): pass")
+        assert len(c) == 2
+
+
+class TestFlag:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert call_graph_enabled() is False
+
+    def test_truthy(self, monkeypatch):
+        for v in ("1", "true", "On", "yes"):
+            monkeypatch.setenv(ENV_VAR, v)
+            assert call_graph_enabled() is True
+
+
+class TestBuildGraph:
+    def test_end_to_end_cross_file(self):
+        if not _HAS_TS:
+            pytest.skip("tree-sitter not installed")
+        files = {
+            "app.py": "from pkg.util import helper\n\ndef main():\n    return helper()\n",
+            "pkg/util.py": "def helper():\n    return 1\n",
+        }
+        g = graph.build_graph(files)
+        names = {d.name for d in g.defines}
+        assert {"main", "helper"} <= names
+        # cross-file import resolved to the defining file
+        imp = next(i for i in g.imports if i.name == "helper")
+        assert imp.resolved == "pkg/util.py"
+        # reachability across the project graph
+        assert graph.reachability(g, "main", "helper") is True
+
+    def test_ignores_non_python(self):
+        g = graph.build_graph({"a.md": "# not code", "b.json": "{}"})
+        assert g.defines == []

--- a/v3-service/Dockerfile
+++ b/v3-service/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 # Copy benchmark modules (V3 pipeline depends on them)
 COPY benchmark/ /app/benchmark/
 COPY v3-service/main.py /app/main.py
+# Structural call-graph reasoning (issue #39): tree-sitter-backed call graph.
+# Pure stdlib + the tree-sitter grammars installed below; no extra deps.
+COPY v3-service/graph/ /app/graph/
 
 # Install Python deps
 RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu

--- a/v3-service/Dockerfile
+++ b/v3-service/Dockerfile
@@ -21,7 +21,8 @@ RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/wh
 RUN pip install --no-cache-dir \
         tree_sitter \
         tree_sitter_python \
-        tree_sitter_html
+        tree_sitter_html \
+        tree_sitter_javascript
 
 EXPOSE 8070
 

--- a/v3-service/graph/__init__.py
+++ b/v3-service/graph/__init__.py
@@ -1,0 +1,85 @@
+"""Structural call-graph reasoning (issue #39).
+
+A faithful Python port of the chiasmus call-graph engine
+(https://github.com/yogthos/chiasmus, `src/graph/`), scoped to what the four
+shipped #39 integration points need. Builds a precomputed CodeGraph from
+tree-sitter extraction and answers callers / callees / reachability / path /
+impact / cycles / dead-code / entry-points natively (O(V+E), no solver), with a
+per-file-hash cache for incremental recompute. Prolog facts are emitted (facts.py)
+for the optional Phase 5 solver layer.
+
+Provenance (ported behavior-for-behavior):
+  types.py    <- src/graph/types.ts
+  extract.py  <- src/graph/extractor.ts (walkPython)
+  analyses.py <- src/graph/native-analyses.ts + entry-points.ts
+  facts.py    <- src/graph/facts.ts
+  resolve.py  <- src/graph/suffix-index.ts (adapted to Python modules)
+  cache.py    <- src/graph/cache.ts (in-process)
+
+See docs/reports/CALL_GRAPH_REASONING_V3.md.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .types import (
+    CodeGraph,
+    DefinesFact,
+    CallsFact,
+    ImportsFact,
+    ExportsFact,
+    ContainsFact,
+    FileNode,
+)
+from .extract import extract_file, is_python, available as extraction_available
+from .resolve import resolve_imports
+from .cache import FileGraphCache, default_cache, file_hash
+from .analyses import (
+    callers,
+    callees,
+    reachability,
+    path,
+    impact,
+    cycles,
+    dead_code,
+    detect_entry_points,
+    run_analysis,
+)
+from .facts import graph_to_prolog, escape_atom
+from .resolve_calls import unresolved_calls, direct_call_names
+from .flags import call_graph_enabled, ENV_VAR as CALL_GRAPH_ENV_VAR
+
+
+def build_graph(file_map: Dict[str, str], cache: Optional[FileGraphCache] = None) -> CodeGraph:
+    """Build a project CodeGraph from {rel_path: content}.
+
+    Only Python files contribute today. Per-file extraction is cached on a
+    content hash (incremental recompute), then imports are resolved across the
+    whole batch. Pass a FileGraphCache to reuse extraction across calls; omit it
+    for a one-shot (uses the process-default cache)."""
+    cache = cache or default_cache()
+    graph = CodeGraph()
+    py_paths: List[str] = []
+    for rel, content in file_map.items():
+        if not is_python(rel):
+            continue
+        py_paths.append(rel)
+        graph.merge(cache.get_or_extract(rel, content))
+    resolve_imports(graph, py_paths)
+    return graph
+
+
+__all__ = [
+    "CodeGraph", "DefinesFact", "CallsFact", "ImportsFact", "ExportsFact",
+    "ContainsFact", "FileNode",
+    "extract_file", "is_python", "extraction_available",
+    "resolve_imports",
+    "FileGraphCache", "default_cache", "file_hash",
+    "callers", "callees", "reachability", "path", "impact", "cycles",
+    "dead_code", "detect_entry_points", "run_analysis",
+    "graph_to_prolog", "escape_atom",
+    "unresolved_calls", "direct_call_names",
+    "call_graph_enabled", "CALL_GRAPH_ENV_VAR",
+    "build_graph",
+]

--- a/v3-service/graph/__init__.py
+++ b/v3-service/graph/__init__.py
@@ -32,7 +32,10 @@ from .types import (
     ContainsFact,
     FileNode,
 )
-from .extract import extract_file, is_python, available as extraction_available
+from .extract import (
+    extract_file, is_python, is_js, is_supported,
+    available as extraction_available, js_available,
+)
 from .resolve import resolve_imports
 from .cache import FileGraphCache, default_cache, file_hash
 from .analyses import (
@@ -44,28 +47,34 @@ from .analyses import (
     cycles,
     dead_code,
     detect_entry_points,
+    complexity,
     run_analysis,
 )
 from .facts import graph_to_prolog, escape_atom
+from .datalog import Datalog, Var, reaches_engine, reachable_pairs, solver_reaches
 from .resolve_calls import unresolved_calls, direct_call_names
+from .context import repair_context, symbol_neighborhood
 from .flags import call_graph_enabled, ENV_VAR as CALL_GRAPH_ENV_VAR
 
 
 def build_graph(file_map: Dict[str, str], cache: Optional[FileGraphCache] = None) -> CodeGraph:
     """Build a project CodeGraph from {rel_path: content}.
 
-    Only Python files contribute today. Per-file extraction is cached on a
-    content hash (incremental recompute), then imports are resolved across the
-    whole batch. Pass a FileGraphCache to reuse extraction across calls; omit it
-    for a one-shot (uses the process-default cache)."""
+    Python and JavaScript files contribute (issue #39 Phase 6); others are
+    skipped. Per-file extraction is cached on a content hash (incremental
+    recompute), then Python imports are resolved across the batch. Pass a
+    FileGraphCache to reuse extraction across calls; omit it for a one-shot."""
     cache = cache or default_cache()
     graph = CodeGraph()
     py_paths: List[str] = []
     for rel, content in file_map.items():
-        if not is_python(rel):
+        if not is_supported(rel):
             continue
-        py_paths.append(rel)
+        if is_python(rel):
+            py_paths.append(rel)
         graph.merge(cache.get_or_extract(rel, content))
+    # Import resolution is Python-only for now; JS imports stay unresolved
+    # (the analyses don't depend on resolution).
     resolve_imports(graph, py_paths)
     return graph
 
@@ -73,13 +82,16 @@ def build_graph(file_map: Dict[str, str], cache: Optional[FileGraphCache] = None
 __all__ = [
     "CodeGraph", "DefinesFact", "CallsFact", "ImportsFact", "ExportsFact",
     "ContainsFact", "FileNode",
-    "extract_file", "is_python", "extraction_available",
+    "extract_file", "is_python", "is_js", "is_supported",
+    "extraction_available", "js_available",
     "resolve_imports",
     "FileGraphCache", "default_cache", "file_hash",
     "callers", "callees", "reachability", "path", "impact", "cycles",
-    "dead_code", "detect_entry_points", "run_analysis",
+    "dead_code", "detect_entry_points", "complexity", "run_analysis",
     "graph_to_prolog", "escape_atom",
+    "Datalog", "Var", "reaches_engine", "reachable_pairs", "solver_reaches",
     "unresolved_calls", "direct_call_names",
+    "repair_context", "symbol_neighborhood",
     "call_graph_enabled", "CALL_GRAPH_ENV_VAR",
     "build_graph",
 ]

--- a/v3-service/graph/analyses.py
+++ b/v3-service/graph/analyses.py
@@ -1,0 +1,356 @@
+"""Native O(V+E) graph analyses.
+
+Faithful port of chiasmus `src/graph/native-analyses.ts` and
+`src/graph/entry-points.ts`. These run directly on the CodeGraph with plain
+traversal (BFS / Tarjan SCC), no solver — the same design choice chiasmus made:
+everyday structural queries are native; the optional Prolog layer (facts.py) is
+for custom rule queries only.
+
+`path` returns the call chain as a list of names (Python-friendly) rather than
+chiasmus's Prolog-list string; the node sequence is identical.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Set
+
+from .types import CodeGraph
+
+
+class _Index:
+    __slots__ = ("adj", "rev", "nodes", "methods", "functions")
+
+    def __init__(self):
+        self.adj: Dict[str, List[str]] = {}
+        self.rev: Dict[str, List[str]] = {}
+        self.nodes: Set[str] = set()
+        self.methods: Set[str] = set()
+        self.functions: Set[str] = set()
+
+
+def _build_index(graph: CodeGraph) -> _Index:
+    # dict-as-ordered-set: preserves first-seen order AND dedups, matching the
+    # JS Set the chiasmus reference uses. A plain set() would reorder (Python set
+    # iteration is hash-seeded, not insertion-ordered), making path/impact/cycles
+    # nondeterministic.
+    adj: Dict[str, dict] = {}
+    rev: Dict[str, dict] = {}
+    idx = _Index()
+    for c in graph.calls:
+        idx.nodes.add(c.caller)
+        idx.nodes.add(c.callee)
+        adj.setdefault(c.caller, {})[c.callee] = None
+        rev.setdefault(c.callee, {})[c.caller] = None
+    for d in graph.defines:
+        idx.nodes.add(d.name)
+        if d.kind == "method":
+            idx.methods.add(d.name)
+        elif d.kind == "function":
+            idx.functions.add(d.name)
+    for k, vs in adj.items():
+        idx.adj[k] = list(vs.keys())
+    for k, vs in rev.items():
+        idx.rev[k] = list(vs.keys())
+    return idx
+
+
+def _resolve_targets(graph: CodeGraph, target: str) -> List[str]:
+    """Match a user-supplied name to graph nodes. Exact match wins; otherwise a
+    bare name matches any `<ns>/target` suffix (namespaced languages). A target
+    that already contains `/` is treated as fully qualified (exact only)."""
+    # Ordered set (first-seen) so suffix matches come out in a stable order.
+    all_names: "dict[str, None]" = {}
+    for d in graph.defines:
+        all_names.setdefault(d.name, None)
+    for c in graph.calls:
+        all_names.setdefault(c.caller, None)
+        all_names.setdefault(c.callee, None)
+    if target in all_names:
+        return [target]
+    if "/" in target:
+        return []
+    suffix = f"/{target}"
+    return [n for n in all_names if n.endswith(suffix)]
+
+
+def _bfs(adj: Dict[str, List[str]], source: str) -> List[str]:
+    """Nodes reachable from `source` (including it), in BFS discovery order.
+    Order matters: `impact` emits results in this order to match chiasmus, whose
+    JS Set preserves insertion order."""
+    seen = {source}
+    queue = [source]
+    head = 0
+    while head < len(queue):
+        u = queue[head]
+        head += 1
+        for v in adj.get(u, ()):
+            if v not in seen:
+                seen.add(v)
+                queue.append(v)
+    return queue
+
+
+def callers(graph: CodeGraph, target: str) -> List[str]:
+    """Direct callers of `target`, deduplicated, in first-seen order."""
+    targets = set(_resolve_targets(graph, target))
+    if not targets:
+        return []
+    seen: Set[str] = set()
+    out: List[str] = []
+    for c in graph.calls:
+        if c.callee in targets and c.caller not in seen:
+            seen.add(c.caller)
+            out.append(c.caller)
+    return out
+
+
+def callees(graph: CodeGraph, source: str) -> List[str]:
+    """Direct callees of `source`, deduplicated, in first-seen order."""
+    sources = set(_resolve_targets(graph, source))
+    if not sources:
+        return []
+    seen: Set[str] = set()
+    out: List[str] = []
+    for c in graph.calls:
+        if c.caller in sources and c.callee not in seen:
+            seen.add(c.callee)
+            out.append(c.callee)
+    return out
+
+
+def reachability(graph: CodeGraph, frm: str, to: str) -> bool:
+    """Is `to` reachable from `frm` through any call chain? A self-pair holds
+    only via a real self-edge (matching the Prolog reaches/2 semantics)."""
+    idx = _build_index(graph)
+    from_targets = _resolve_targets(graph, frm)
+    to_targets = set(_resolve_targets(graph, to))
+    if not from_targets or not to_targets:
+        return False
+    for f in from_targets:
+        if f not in idx.nodes:
+            continue
+        if f in to_targets and f in idx.adj.get(f, ()):
+            return True
+        reached = set(_bfs(idx.adj, f))
+        for t in to_targets:
+            if t == f:
+                continue
+            if t in reached:
+                return True
+    return False
+
+
+def path(graph: CodeGraph, frm: str, to: str) -> List[str]:
+    """Shortest call chain from `frm` to `to` as a list of names, or []."""
+    idx = _build_index(graph)
+    from_targets = _resolve_targets(graph, frm)
+    to_targets = set(_resolve_targets(graph, to))
+    if not from_targets or not to_targets:
+        return []
+    for f in from_targets:
+        if f not in idx.nodes:
+            continue
+        if f in to_targets and f in idx.adj.get(f, ()):
+            return [f, f]
+        parent: Dict[str, str] = {}
+        seen = {f}
+        queue = [f]
+        head = 0
+        target: Optional[str] = None
+        while head < len(queue):
+            u = queue[head]
+            head += 1
+            hit = False
+            for v in idx.adj.get(u, ()):
+                if v in seen:
+                    continue
+                seen.add(v)
+                parent[v] = u
+                if v in to_targets:
+                    target = v
+                    hit = True
+                    break
+                queue.append(v)
+            if hit:
+                break
+        if target is None:
+            continue
+        chain: List[str] = []
+        cur: Optional[str] = target
+        while cur is not None:
+            chain.append(cur)
+            cur = parent.get(cur)
+        chain.reverse()
+        return chain
+    return []
+
+
+def impact(graph: CodeGraph, target: str) -> List[str]:
+    """Transitive callers of `target` — everything that could break if it
+    changes. Unions impact sets across namespace-qualified matches."""
+    idx = _build_index(graph)
+    targets = _resolve_targets(graph, target)
+    if not targets:
+        return []
+    target_set = set(targets)
+    union: List[str] = []
+    seen: Set[str] = set()
+    for t in targets:
+        if t not in idx.nodes:
+            continue
+        reached = _bfs(idx.rev, t)
+        self_loop = t in idx.adj.get(t, ())
+        for n in reached:
+            if n == t:
+                if self_loop and n not in seen:
+                    seen.add(n)
+                    union.append(n)
+                continue
+            if n in target_set or n in seen:
+                continue
+            seen.add(n)
+            union.append(n)
+    return union
+
+
+def cycles(graph: CodeGraph) -> List[str]:
+    """Function-level cycles via iterative Tarjan SCC. Methods are excluded
+    because unqualified method names collide across classes and produce phantom
+    cycles (faithful to chiasmus)."""
+    idx = _build_index(graph)
+    func_adj: Dict[str, List[str]] = {}
+    func_nodes: "dict[str, None]" = {}  # ordered set: deterministic SCC start order
+    for u, vs in idx.adj.items():
+        if u in idx.methods:
+            continue
+        kept = [v for v in vs if v not in idx.methods]
+        if kept:
+            func_adj[u] = kept
+            func_nodes.setdefault(u, None)
+            for v in kept:
+                func_nodes.setdefault(v, None)
+
+    index = 0
+    indices: Dict[str, int] = {}
+    lowlink: Dict[str, int] = {}
+    on_stack: Set[str] = set()
+    stack: List[str] = []
+    result: "dict[str, None]" = {}  # ordered set: stable result order
+
+    for start in func_nodes:
+        if start in indices:
+            continue
+        work = [[start, 0, func_adj.get(start, [])]]  # [v, it, succs]
+        indices[start] = index
+        lowlink[start] = index
+        index += 1
+        stack.append(start)
+        on_stack.add(start)
+
+        while work:
+            frame = work[-1]
+            v, it, succs = frame[0], frame[1], frame[2]
+            if it < len(succs):
+                w = succs[it]
+                frame[1] += 1
+                if w not in indices:
+                    indices[w] = index
+                    lowlink[w] = index
+                    index += 1
+                    stack.append(w)
+                    on_stack.add(w)
+                    work.append([w, 0, func_adj.get(w, [])])
+                elif w in on_stack:
+                    if indices[w] < lowlink[v]:
+                        lowlink[v] = indices[w]
+            else:
+                if lowlink[v] == indices[v]:
+                    scc: List[str] = []
+                    while True:
+                        w = stack.pop()
+                        on_stack.discard(w)
+                        scc.append(w)
+                        if w == v:
+                            break
+                    if len(scc) > 1:
+                        for n in scc:
+                            result.setdefault(n, None)
+                    else:
+                        solo = scc[0]
+                        if solo in func_adj.get(solo, ()):
+                            result.setdefault(solo, None)
+                work.pop()
+                if work:
+                    parent = work[-1][0]
+                    if lowlink[v] < lowlink[parent]:
+                        lowlink[parent] = lowlink[v]
+
+    return list(result.keys())
+
+
+def detect_entry_points(graph: CodeGraph) -> List[str]:
+    """Heuristic entry points for dead-code: exported functions with zero
+    in-degree, then all exports, then zero-in-degree functions. Methods
+    excluded. Faithful to chiasmus entry-points.ts."""
+    called = {c.callee for c in graph.calls}
+    method_names = {d.name for d in graph.defines if d.kind == "method"}
+    function_names = {d.name for d in graph.defines if d.kind == "function"}
+
+    exported_fns = [e.name for e in graph.exports if e.name not in method_names]
+    if exported_fns:
+        zero_in = [n for n in exported_fns if n not in called]
+        if zero_in:
+            return sorted(set(zero_in))
+        return sorted(set(exported_fns))
+    roots = [n for n in function_names if n not in called]
+    return sorted(set(roots))
+
+
+def dead_code(graph: CodeGraph, entry_points: Optional[List[str]] = None) -> List[str]:
+    """Functions defined, called by nobody, and not an entry point. Methods
+    excluded (dynamic dispatch can't be statically resolved)."""
+    called = {c.callee for c in graph.calls}
+    entries: Set[str] = set()
+    if entry_points:
+        for ep in entry_points:
+            resolved = _resolve_targets(graph, ep)
+            if not resolved:
+                entries.add(ep)
+            else:
+                entries.update(resolved)
+    else:
+        entries = {e.name for e in graph.exports}
+
+    out: List[str] = []
+    seen: Set[str] = set()
+    for d in graph.defines:
+        if d.kind != "function" or d.name in seen:
+            continue
+        if d.name in called or d.name in entries:
+            continue
+        seen.add(d.name)
+        out.append(d.name)
+    return out
+
+
+def run_analysis(graph: CodeGraph, analysis: str, target: Optional[str] = None,
+                 frm: Optional[str] = None, to: Optional[str] = None,
+                 entry_points: Optional[List[str]] = None):
+    """Dispatch a named analysis. Returns the analysis-specific result."""
+    if analysis == "callers":
+        return callers(graph, target or "")
+    if analysis == "callees":
+        return callees(graph, target or "")
+    if analysis == "reachability":
+        return reachability(graph, frm or "", to or "")
+    if analysis == "path":
+        return path(graph, frm or "", to or "")
+    if analysis == "impact":
+        return impact(graph, target or "")
+    if analysis == "cycles":
+        return cycles(graph)
+    if analysis == "entry-points":
+        return detect_entry_points(graph)
+    if analysis == "dead-code":
+        return dead_code(graph, entry_points)
+    raise ValueError(f"unknown analysis: {analysis}")

--- a/v3-service/graph/analyses.py
+++ b/v3-service/graph/analyses.py
@@ -333,6 +333,32 @@ def dead_code(graph: CodeGraph, entry_points: Optional[List[str]] = None) -> Lis
     return out
 
 
+def complexity(graph: CodeGraph) -> dict:
+    """Graph-shape complexity signal (issue #39 point 2, optional tier
+    enrichment): per-node fan-in (callers) and fan-out (callees), plus the
+    maxima across the graph. Complements cyclomatic complexity, which already
+    ships, with structural coupling — a function called from many places or
+    calling many others is higher-risk to change."""
+    idx = _build_index(graph)
+    nodes = sorted(idx.nodes)
+    per_node = {}
+    max_fan_in = 0
+    max_fan_out = 0
+    for n in nodes:
+        fan_in = len(idx.rev.get(n, ()))
+        fan_out = len(idx.adj.get(n, ()))
+        per_node[n] = {"fan_in": fan_in, "fan_out": fan_out}
+        max_fan_in = max(max_fan_in, fan_in)
+        max_fan_out = max(max_fan_out, fan_out)
+    return {
+        "max_fan_in": max_fan_in,
+        "max_fan_out": max_fan_out,
+        "n_nodes": len(nodes),
+        "n_edges": len(graph.calls),
+        "per_node": per_node,
+    }
+
+
 def run_analysis(graph: CodeGraph, analysis: str, target: Optional[str] = None,
                  frm: Optional[str] = None, to: Optional[str] = None,
                  entry_points: Optional[List[str]] = None):
@@ -353,4 +379,6 @@ def run_analysis(graph: CodeGraph, analysis: str, target: Optional[str] = None,
         return detect_entry_points(graph)
     if analysis == "dead-code":
         return dead_code(graph, entry_points)
+    if analysis == "complexity":
+        return complexity(graph)
     raise ValueError(f"unknown analysis: {analysis}")

--- a/v3-service/graph/cache.py
+++ b/v3-service/graph/cache.py
@@ -1,0 +1,70 @@
+"""Per-file content-hash cache for call-graph extraction.
+
+Models chiasmus `src/graph/cache.ts` at the level the substrate needs: cache the
+per-file CodeGraph keyed on a hash of (path, content), so building the graph for
+a project only re-extracts the files whose content changed. This is the
+"hang it off edited-file tracking, re-run touched files on write" idea from #39.
+
+In-process (a module-level dict) rather than chiasmus's on-disk store — enough
+for incremental recompute within a running v3-service. A bounded LRU keeps it
+from growing without limit across many projects.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from collections import OrderedDict
+from typing import Optional
+
+from .extract import extract_file
+from .types import CodeGraph
+
+
+def file_hash(path: str, content: str) -> str:
+    h = hashlib.sha256()
+    h.update(content.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(path.encode("utf-8"))
+    return h.hexdigest()
+
+
+class FileGraphCache:
+    """Bounded LRU mapping file-hash -> per-file CodeGraph."""
+
+    def __init__(self, max_entries: int = 4096):
+        self._max = max_entries
+        self._store: "OrderedDict[str, CodeGraph]" = OrderedDict()
+
+    def get_or_extract(self, path: str, content: str) -> CodeGraph:
+        key = file_hash(path, content)
+        hit = self._store.get(key)
+        if hit is not None:
+            self._store.move_to_end(key)
+            # Return a copy: callers (build_graph -> resolve_imports) mutate
+            # ImportsFact.resolved in place, which would otherwise corrupt the
+            # cached per-file graph and leak resolution state across requests
+            # with different file sets.
+            return copy.deepcopy(hit)
+        g = extract_file(path, content)
+        self._store[key] = g
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)
+        return copy.deepcopy(g)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+# Shared default cache for the running process.
+_DEFAULT_CACHE: Optional[FileGraphCache] = None
+
+
+def default_cache() -> FileGraphCache:
+    global _DEFAULT_CACHE
+    if _DEFAULT_CACHE is None:
+        _DEFAULT_CACHE = FileGraphCache()
+    return _DEFAULT_CACHE

--- a/v3-service/graph/context.py
+++ b/v3-service/graph/context.py
@@ -1,0 +1,114 @@
+"""Graph-backed context builders for the repair loop and symbol injection.
+
+Phase 2 (#39 point 3): `repair_context` replaces the shipped 1-hop
+call_chain_context with a real reachability slice — the path from an entry point
+down to the failing function, its transitive callers (impact set), and its
+callees. Phase 3 (#39 point 4): `symbol_neighborhood` returns a named symbol's
+graph neighborhood so context injection can pull in the structurally related
+code instead of name-matched snippets.
+
+Both reuse the native analyses; no new traversal logic.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from . import analyses
+from .extract import is_python
+
+
+def _project_graph(file_map: Dict[str, str]):
+    from . import build_graph
+    return build_graph(file_map)
+
+
+def symbol_neighborhood(
+    file_map: Dict[str, str], symbol: str, max_items: int = 10
+) -> dict:
+    """The graph neighborhood of `symbol`: direct callers, direct callees, the
+    transitive impact set (everything that can reach it), and the files that
+    define it. Empty lists when the symbol isn't in the graph."""
+    graph = _project_graph(file_map)
+    defined_files = sorted({d.file for d in graph.defines if d.name == symbol})
+    return {
+        "symbol": symbol,
+        "defined_in": defined_files,
+        "callers": analyses.callers(graph, symbol)[:max_items],
+        "callees": analyses.callees(graph, symbol)[:max_items],
+        "impact": analyses.impact(graph, symbol)[:max_items],
+    }
+
+
+def _entry_path_to(graph, function_name: str) -> List[str]:
+    """A call path from some entry point down to `function_name`, or []."""
+    for entry in analyses.detect_entry_points(graph):
+        if entry == function_name:
+            continue
+        chain = analyses.path(graph, entry, function_name)
+        if chain:
+            return chain
+    return []
+
+
+def repair_context(
+    file_map: Dict[str, str],
+    function_name: str,
+    max_items: int = 8,
+) -> str:
+    """Markdown reachability slice around a failing function for the repair
+    model. Returns "" when the function isn't in the graph (caller skips the
+    block rather than diluting the error with a useless 'no matches')."""
+    if not function_name or not file_map:
+        return ""
+    if not any(is_python(p) for p in file_map):
+        return ""
+
+    graph = _project_graph(file_map)
+    defined_files = sorted({d.file for d in graph.defines if d.name == function_name})
+    if not defined_files:
+        return ""
+
+    direct_callers = analyses.callers(graph, function_name)
+    impact = analyses.impact(graph, function_name)
+    callees = analyses.callees(graph, function_name)
+    witness = _entry_path_to(graph, function_name)
+
+    sb: List[str] = [f"## Call-graph context for failing function `{function_name}`", ""]
+    sb.append(f"Defined in: {', '.join('`' + f + '`' for f in defined_files)}")
+    sb.append("")
+
+    if witness:
+        sb.append("**Call path from an entry point (how execution reaches it):**")
+        sb.append("`" + " → ".join(witness) + "`")
+        sb.append("")
+
+    if direct_callers:
+        capped = direct_callers[:max_items]
+        sb.append(f"**Direct callers ({len(direct_callers)}):** "
+                  + ", ".join("`" + c + "`" for c in capped)
+                  + (f" … +{len(direct_callers) - max_items} more" if len(direct_callers) > max_items else ""))
+    else:
+        sb.append("**Direct callers:** none (entry point or called only externally)")
+
+    # The impact set beyond the direct callers is the transitive blast radius.
+    transitive = [n for n in impact if n not in set(direct_callers)]
+    if transitive:
+        capped = transitive[:max_items]
+        sb.append(f"**Also transitively affected ({len(transitive)}):** "
+                  + ", ".join("`" + c + "`" for c in capped)
+                  + (f" … +{len(transitive) - max_items} more" if len(transitive) > max_items else ""))
+
+    if callees:
+        capped = callees[:max_items]
+        sb.append(f"**Calls out to ({len(callees)}):** "
+                  + ", ".join("`" + c + "`" for c in capped)
+                  + (f" … +{len(callees) - max_items} more" if len(callees) > max_items else ""))
+    else:
+        sb.append(f"**Calls out to:** none (`{function_name}` is a leaf)")
+
+    sb.append("")
+    sb.append(f"Scope the fix with this: changing what `{function_name}` returns or "
+              "raises can break everything in the affected set above; changing what "
+              "it calls usually can't.")
+    return "\n".join(sb)

--- a/v3-service/graph/context.py
+++ b/v3-service/graph/context.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Dict, List
 
 from . import analyses
-from .extract import is_python
+from .extract import is_supported
 
 
 def _project_graph(file_map: Dict[str, str]):
@@ -24,12 +24,16 @@ def _project_graph(file_map: Dict[str, str]):
 
 
 def symbol_neighborhood(
-    file_map: Dict[str, str], symbol: str, max_items: int = 10
+    file_map: Dict[str, str], symbol: str, max_items: int = 10, graph=None
 ) -> dict:
     """The graph neighborhood of `symbol`: direct callers, direct callees, the
     transitive impact set (everything that can reach it), and the files that
-    define it. Empty lists when the symbol isn't in the graph."""
-    graph = _project_graph(file_map)
+    define it. Empty lists when the symbol isn't in the graph.
+
+    Pass a prebuilt `graph` to neighborhood many symbols without rebuilding the
+    project graph per symbol (the caller should build it once)."""
+    if graph is None:
+        graph = _project_graph(file_map)
     defined_files = sorted({d.file for d in graph.defines if d.name == symbol})
     return {
         "symbol": symbol,
@@ -61,7 +65,7 @@ def repair_context(
     block rather than diluting the error with a useless 'no matches')."""
     if not function_name or not file_map:
         return ""
-    if not any(is_python(p) for p in file_map):
+    if not any(is_supported(p) for p in file_map):
         return ""
 
     graph = _project_graph(file_map)
@@ -92,7 +96,8 @@ def repair_context(
         sb.append("**Direct callers:** none (entry point or called only externally)")
 
     # The impact set beyond the direct callers is the transitive blast radius.
-    transitive = [n for n in impact if n not in set(direct_callers)]
+    direct_set = set(direct_callers)
+    transitive = [n for n in impact if n not in direct_set]
     if transitive:
         capped = transitive[:max_items]
         sb.append(f"**Also transitively affected ({len(transitive)}):** "

--- a/v3-service/graph/datalog.py
+++ b/v3-service/graph/datalog.py
@@ -1,0 +1,137 @@
+"""Minimal in-process Datalog evaluator over call-graph facts (issue #39,
+Phase 5 — the optional "+ solver" layer).
+
+The native analyses answer the everyday queries; this adds rule-based querying
+over the same facts for the cases native traversal can't express cleanly
+(arbitrary derived relations, transitive closure as a relation). It is a small,
+dependency-free, bounded semi-naive-style fixpoint evaluator — NOT a full
+SWI-Prolog. The Prolog facts emitted by facts.py remain the bridge to a real
+external solver (chiasmus_verify / SWI-Prolog) when arbitrary rules are needed;
+this engine covers the in-process, dependency-free case.
+
+Correctness is anchored to the native layer: the built-in `reaches` closure is
+cross-checked against analyses.reachability in the test suite.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set, Tuple
+
+from .types import CodeGraph
+
+
+class Var:
+    """A Datalog variable. Distinct from string constants (which may be
+    capitalized class names), so we never confuse a name with a variable."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"?{self.name}"
+
+
+Term = object  # Var | str
+Literal = Tuple[str, List[Term]]
+
+
+class Datalog:
+    def __init__(self):
+        self.facts: Dict[str, Set[tuple]] = {}
+        self.rules: List[Tuple[Literal, List[Literal]]] = []
+
+    def add_fact(self, pred: str, *args: str) -> None:
+        self.facts.setdefault(pred, set()).add(tuple(args))
+
+    def add_rule(self, head: Literal, body: List[Literal]) -> None:
+        self.rules.append((head, body))
+
+    def run(self, max_iter: int = 10000) -> "Datalog":
+        """Naive fixpoint: re-derive until no new tuple appears or the iteration
+        cap (runaway guard) is hit."""
+        it = 0
+        changed = True
+        while changed and it < max_iter:
+            changed = False
+            it += 1
+            for head, body in self.rules:
+                hpred, hterms = head
+                rel = self.facts.setdefault(hpred, set())
+                for binding in self._join(body, {}):
+                    htuple = tuple(self._subst(t, binding) for t in hterms)
+                    if htuple not in rel:
+                        rel.add(htuple)
+                        changed = True
+        return self
+
+    def _join(self, body: List[Literal], binding: dict):
+        if not body:
+            yield dict(binding)
+            return
+        (pred, terms) = body[0]
+        rest = body[1:]
+        for fact in tuple(self.facts.get(pred, ())):
+            b2 = self._unify(terms, fact, binding)
+            if b2 is not None:
+                yield from self._join(rest, b2)
+
+    @staticmethod
+    def _unify(terms: List[Term], fact: tuple, binding: dict):
+        if len(terms) != len(fact):
+            return None
+        b = dict(binding)
+        for t, val in zip(terms, fact):
+            if isinstance(t, Var):
+                if t.name in b:
+                    if b[t.name] != val:
+                        return None
+                else:
+                    b[t.name] = val
+            elif t != val:
+                return None
+        return b
+
+    @staticmethod
+    def _subst(t: Term, binding: dict):
+        return binding[t.name] if isinstance(t, Var) else t
+
+    def query(self, pred: str, *pattern: Term) -> List[dict]:
+        """Return all variable bindings for which `pred(pattern)` holds."""
+        out: List[dict] = []
+        for fact in self.facts.get(pred, ()):
+            b = self._unify(list(pattern), fact, {})
+            if b is not None:
+                out.append(b)
+        return out
+
+
+def _load_calls(graph: CodeGraph, dl: Datalog) -> None:
+    for c in graph.calls:
+        dl.add_fact("calls", c.caller, c.callee)
+
+
+def reaches_engine(graph: CodeGraph) -> Datalog:
+    """A Datalog DB with the calls facts and the built-in transitive-reachability
+    rules evaluated to fixpoint."""
+    dl = Datalog()
+    _load_calls(graph, dl)
+    a, b, m = Var("A"), Var("B"), Var("M")
+    dl.add_rule(("reaches", [a, b]), [("calls", [a, b])])
+    dl.add_rule(("reaches", [a, b]), [("calls", [a, m]), ("reaches", [m, b])])
+    return dl.run()
+
+
+def reachable_pairs(graph: CodeGraph) -> List[Tuple[str, str]]:
+    """The full transitive-closure relation `reaches/2` as (from, to) pairs —
+    a relation the native single-pair API doesn't expose directly."""
+    dl = reaches_engine(graph)
+    return sorted(dl.facts.get("reaches", set()))
+
+
+def solver_reaches(graph: CodeGraph, frm: str, to: str) -> bool:
+    """Reachability via the Datalog engine. Semantically matches
+    analyses.reachability (a self-pair holds only through a real call step)."""
+    dl = reaches_engine(graph)
+    return (frm, to) in dl.facts.get("reaches", set())

--- a/v3-service/graph/datalog.py
+++ b/v3-service/graph/datalog.py
@@ -60,6 +60,11 @@ class Datalog:
                 hpred, hterms = head
                 rel = self.facts.setdefault(hpred, set())
                 for binding in self._join(body, {}):
+                    # Skip if a head variable is unbound by the body (an unsafe
+                    # rule) rather than raising — keeps the public engine robust
+                    # against caller-supplied rules. The built-in rules are safe.
+                    if any(isinstance(t, Var) and t.name not in binding for t in hterms):
+                        continue
                     htuple = tuple(self._subst(t, binding) for t in hterms)
                     if htuple not in rel:
                         rel.add(htuple)

--- a/v3-service/graph/extract.py
+++ b/v3-service/graph/extract.py
@@ -1,0 +1,217 @@
+"""Tree-sitter extraction: Python source → CodeGraph facts.
+
+Mirrors the `walkPython` extractor in chiasmus `src/graph/extractor.ts`,
+reimplemented on the Python tree-sitter bindings that v3-service already
+depends on (tree_sitter + tree_sitter_python). Emits defines / calls / imports /
+exports / contains facts. Python-first (issue #39); other languages plug in via
+the same shape later.
+
+Extraction is best-effort: if tree-sitter is unavailable or a file fails to
+parse, that file contributes nothing rather than raising.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Set
+
+from .types import (
+    CallsFact,
+    CodeGraph,
+    ContainsFact,
+    DefinesFact,
+    ExportsFact,
+    FileNode,
+    ImportsFact,
+)
+
+try:
+    import tree_sitter as _ts
+    import tree_sitter_python as _tsp
+
+    _PY_LANG = _ts.Language(_tsp.language())
+    _AVAILABLE = True
+except Exception:  # pragma: no cover - exercised only where grammar is absent
+    _PY_LANG = None
+    _AVAILABLE = False
+
+
+def available() -> bool:
+    return _AVAILABLE
+
+
+def _text(node) -> str:
+    t = node.text
+    return t.decode("utf-8", "replace") if isinstance(t, (bytes, bytearray)) else str(t)
+
+
+def _collapse_signature(sig: str) -> str:
+    return re.sub(r"\s+", " ", sig).strip()
+
+
+def _extract_python_signature(node) -> Optional[str]:
+    params = node.child_by_field_name("parameters")
+    if params is None:
+        return None
+    sig = _text(params)
+    ret = node.child_by_field_name("return_type")
+    if ret is not None:
+        sig += " -> " + _text(ret)
+    return _collapse_signature(sig)
+
+
+def _find_enclosing_class(node) -> Optional[str]:
+    current = node.parent
+    while current is not None:
+        if current.type == "class_definition":
+            name = current.child_by_field_name("name")
+            return _text(name) if name is not None else None
+        current = current.parent
+    return None
+
+
+def _resolve_callee(call_node) -> Optional[str]:
+    fn = call_node.child_by_field_name("function")
+    if fn is None:
+        return None
+    if fn.type == "identifier":
+        return _text(fn)
+    if fn.type == "attribute":
+        # obj.method() -> method (bare name, matching chiasmus)
+        attr = fn.child_by_field_name("attribute")
+        return _text(attr) if attr is not None else None
+    return None
+
+
+def _walk(node, file_path: str, scope: List[str], g: CodeGraph, call_set: Set[str]) -> None:
+    t = node.type
+
+    if t == "function_definition":
+        name_node = node.child_by_field_name("name")
+        if name_node is not None:
+            name = _text(name_node)
+            enclosing = _find_enclosing_class(node)
+            kind = "method" if enclosing else "function"
+            g.defines.append(DefinesFact(
+                file=file_path, name=name, kind=kind,
+                line=node.start_point[0] + 1,
+                signature=_extract_python_signature(node),
+            ))
+            if enclosing:
+                g.contains.append(ContainsFact(parent=enclosing, child=name))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "class_definition":
+        name_node = node.child_by_field_name("name")
+        if name_node is not None:
+            name = _text(name_node)
+            g.defines.append(DefinesFact(
+                file=file_path, name=name, kind="class",
+                line=node.start_point[0] + 1,
+            ))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "call":
+        callee = _resolve_callee(node)
+        caller = scope[-1] if scope else None
+        if callee and caller:
+            key = f"{caller}->{callee}"
+            if key not in call_set:
+                call_set.add(key)
+                g.calls.append(CallsFact(caller=caller, callee=callee))
+        # fall through to children to catch nested calls in args
+
+    elif t == "import_statement":
+        for i in range(node.child_count):
+            child = node.child(i)
+            if child.type == "dotted_name":
+                txt = _text(child)
+                g.imports.append(ImportsFact(file=file_path, name=txt, source=txt))
+            elif child.type == "aliased_import":
+                dotted = child.child_by_field_name("name")
+                if dotted is not None:
+                    alias_node = child.child_by_field_name("alias")
+                    alias = _text(alias_node) if alias_node is not None else _text(dotted)
+                    g.imports.append(ImportsFact(file=file_path, name=alias, source=_text(dotted)))
+        return
+
+    elif t == "import_from_statement":
+        module_node = node.child_by_field_name("module_name")
+        source = _text(module_node) if module_node is not None else ""
+        # `from mod import *` -> record a wildcard so the veto can resolve it to
+        # the module's actual exports (or stay lenient if the module is opaque).
+        if any(node.child(i).type == "wildcard_import" for i in range(node.child_count)):
+            g.imports.append(ImportsFact(file=file_path, name="*", source=source))
+            return
+        name_node = node.child_by_field_name("name")
+        if name_node is not None and name_node.type in ("dotted_name", "identifier"):
+            g.imports.append(ImportsFact(file=file_path, name=_text(name_node), source=source))
+        for i in range(node.child_count):
+            child = node.child(i)
+            if child.type == "dotted_name" and child != module_node and child != name_node:
+                g.imports.append(ImportsFact(file=file_path, name=_text(child), source=source))
+            elif child.type == "aliased_import":
+                imp = child.child_by_field_name("name")
+                alias = child.child_by_field_name("alias")
+                if imp is not None:
+                    nm = _text(alias) if alias is not None else _text(imp)
+                    g.imports.append(ImportsFact(file=file_path, name=nm, source=source))
+        return
+
+    for i in range(node.child_count):
+        _walk(node.child(i), file_path, scope, g, call_set)
+
+
+def _module_exports(g: CodeGraph, file_path: str) -> None:
+    """Python has no explicit export syntax; treat top-level (non-method)
+    defines as the file's exported names so entry-point / dead-code analysis
+    has a sensible default set."""
+    methods = {d.name for d in g.defines if d.file == file_path and d.kind == "method"}
+    seen: Set[str] = set()
+    for d in g.defines:
+        if d.file != file_path or d.kind == "method":
+            continue
+        if d.name in seen:
+            continue
+        seen.add(d.name)
+        g.exports.append(ExportsFact(file=file_path, name=d.name))
+    # methods captured above only to exclude them; reference to satisfy linters
+    _ = methods
+
+
+def extract_file(file_path: str, content: str) -> CodeGraph:
+    """Extract a CodeGraph for a single Python file. Returns an empty graph when
+    tree-sitter is unavailable or the source cannot be parsed."""
+    g = CodeGraph()
+    if not _AVAILABLE or not content:
+        return g
+    try:
+        parser = _ts.Parser(_PY_LANG)
+        tree = parser.parse(bytes(content, "utf-8"))
+    except Exception:
+        return g
+    # Best-effort: a deeply nested file can blow the recursion limit in _walk;
+    # if extraction fails partway, that file contributes nothing rather than
+    # taking down the whole batch (per the module contract).
+    try:
+        walk_graph = CodeGraph()
+        _walk(tree.root_node, file_path, [], walk_graph, set())
+    except Exception:  # incl. RecursionError on pathologically deep files
+        return g
+    g.merge(walk_graph)
+    g.files.append(FileNode(path=file_path, language="python",
+                            line_count=content.count("\n") + 1))
+    _module_exports(g, file_path)
+    return g
+
+
+def is_python(path: str) -> bool:
+    return path.endswith((".py", ".pyi", ".pyx"))

--- a/v3-service/graph/extract.py
+++ b/v3-service/graph/extract.py
@@ -35,9 +35,24 @@ except Exception:  # pragma: no cover - exercised only where grammar is absent
     _PY_LANG = None
     _AVAILABLE = False
 
+# JavaScript is optional and additive (issue #39, Phase 6): if the grammar isn't
+# installed, .js files simply contribute nothing, like an unsupported language.
+try:
+    import tree_sitter_javascript as _tsjs
+
+    _JS_LANG = _ts.Language(_tsjs.language()) if _AVAILABLE else None
+    _JS_AVAILABLE = _AVAILABLE and _JS_LANG is not None
+except Exception:  # pragma: no cover
+    _JS_LANG = None
+    _JS_AVAILABLE = False
+
 
 def available() -> bool:
     return _AVAILABLE
+
+
+def js_available() -> bool:
+    return _JS_AVAILABLE
 
 
 def _text(node) -> str:
@@ -187,31 +202,173 @@ def _module_exports(g: CodeGraph, file_path: str) -> None:
     _ = methods
 
 
-def extract_file(file_path: str, content: str) -> CodeGraph:
-    """Extract a CodeGraph for a single Python file. Returns an empty graph when
-    tree-sitter is unavailable or the source cannot be parsed."""
+# ─── JavaScript extraction (issue #39, Phase 6) ──────────────
+# Core facts only (defines / calls / imports / contains), modeled on the JS walk
+# in chiasmus extractor.ts. No qualified-name resolution (that's the TS/JS
+# type-env machinery the Python-first port omits); the call graph and its
+# analyses work the same on the bare names.
+
+def _js_enclosing_class(node) -> Optional[str]:
+    current = node.parent
+    while current is not None:
+        if current.type == "class_declaration":
+            nm = current.child_by_field_name("name")
+            return _text(nm) if nm is not None else None
+        current = current.parent
+    return None
+
+
+def _js_callee(call_node) -> Optional[str]:
+    fn = call_node.child_by_field_name("function")
+    if fn is None:
+        return None
+    if fn.type == "identifier":
+        return _text(fn)
+    if fn.type == "member_expression":  # obj.method() -> method (bare)
+        prop = fn.child_by_field_name("property")
+        return _text(prop) if prop is not None else None
+    return None
+
+
+def _walk_js(node, file_path: str, scope: List[str], g: CodeGraph, call_set: Set[str]) -> None:
+    t = node.type
+
+    if t == "function_declaration":
+        nm = node.child_by_field_name("name")
+        if nm is not None:
+            name = _text(nm)
+            g.defines.append(DefinesFact(file_path, name, "function", node.start_point[0] + 1))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk_js(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "class_declaration":
+        nm = node.child_by_field_name("name")
+        if nm is not None:
+            name = _text(nm)
+            g.defines.append(DefinesFact(file_path, name, "class", node.start_point[0] + 1))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk_js(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "method_definition":
+        nm = node.child_by_field_name("name")
+        if nm is not None:
+            name = _text(nm)
+            g.defines.append(DefinesFact(file_path, name, "method", node.start_point[0] + 1))
+            enclosing = _js_enclosing_class(node)
+            if enclosing:
+                g.contains.append(ContainsFact(parent=enclosing, child=name))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk_js(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "variable_declarator":
+        # `const f = () => {}` / `const f = function () {}` -> a function define.
+        value = node.child_by_field_name("value")
+        nm = node.child_by_field_name("name")
+        if value is not None and nm is not None and value.type in ("arrow_function", "function_expression", "function"):
+            name = _text(nm)
+            kind = "method" if _js_enclosing_class(node) else "function"
+            g.defines.append(DefinesFact(file_path, name, kind, node.start_point[0] + 1))
+            scope.append(name)
+            for i in range(node.child_count):
+                _walk_js(node.child(i), file_path, scope, g, call_set)
+            scope.pop()
+            return
+
+    elif t == "call_expression":
+        callee = _js_callee(node)
+        caller = scope[-1] if scope else None
+        if callee and caller:
+            key = f"{caller}->{callee}"
+            if key not in call_set:
+                call_set.add(key)
+                g.calls.append(CallsFact(caller=caller, callee=callee))
+        # fall through to children (args may contain calls)
+
+    elif t == "import_statement":
+        source_node = node.child_by_field_name("source")
+        source = _text(source_node).strip("'\"") if source_node is not None else ""
+        for i in range(node.child_count):
+            clause = node.child(i)
+            if clause.type != "import_clause":
+                continue
+            for j in range(clause.child_count):
+                spec = clause.child(j)
+                if spec.type == "identifier":  # default import
+                    g.imports.append(ImportsFact(file_path, _text(spec), source))
+                elif spec.type == "namespace_import":  # * as ns
+                    for k in range(spec.child_count):
+                        c = spec.child(k)
+                        if c.type == "identifier":
+                            g.imports.append(ImportsFact(file_path, _text(c), source))
+                elif spec.type == "named_imports":  # { a, b as c }
+                    for k in range(spec.child_count):
+                        isp = spec.child(k)
+                        if isp.type == "import_specifier":
+                            alias = isp.child_by_field_name("alias")
+                            nm = isp.child_by_field_name("name")
+                            if nm is not None:
+                                g.imports.append(ImportsFact(
+                                    file_path, _text(alias) if alias is not None else _text(nm), source))
+        return
+
+    for i in range(node.child_count):
+        _walk_js(node.child(i), file_path, scope, g, call_set)
+
+
+def _extract_with(lang, walk, language_name: str, file_path: str, content: str) -> CodeGraph:
     g = CodeGraph()
-    if not _AVAILABLE or not content:
+    if not content:
         return g
     try:
-        parser = _ts.Parser(_PY_LANG)
+        parser = _ts.Parser(lang)
         tree = parser.parse(bytes(content, "utf-8"))
     except Exception:
         return g
-    # Best-effort: a deeply nested file can blow the recursion limit in _walk;
-    # if extraction fails partway, that file contributes nothing rather than
-    # taking down the whole batch (per the module contract).
     try:
         walk_graph = CodeGraph()
-        _walk(tree.root_node, file_path, [], walk_graph, set())
+        walk(tree.root_node, file_path, [], walk_graph, set())
     except Exception:  # incl. RecursionError on pathologically deep files
         return g
     g.merge(walk_graph)
-    g.files.append(FileNode(path=file_path, language="python",
+    g.files.append(FileNode(path=file_path, language=language_name,
                             line_count=content.count("\n") + 1))
-    _module_exports(g, file_path)
     return g
+
+
+def extract_file(file_path: str, content: str) -> CodeGraph:
+    """Extract a CodeGraph for a single supported file. Dispatches by extension
+    (Python or JavaScript). Returns an empty graph when the grammar is
+    unavailable or the source can't be parsed."""
+    if is_python(file_path):
+        if not _AVAILABLE:
+            return CodeGraph()
+        g = _extract_with(_PY_LANG, _walk, "python", file_path, content)
+        if g.files:  # parsed successfully -> synthesize Python's implicit exports
+            _module_exports(g, file_path)
+        return g
+    if is_js(file_path):
+        if not _JS_AVAILABLE:
+            return CodeGraph()
+        return _extract_with(_JS_LANG, _walk_js, "javascript", file_path, content)
+    return CodeGraph()
 
 
 def is_python(path: str) -> bool:
     return path.endswith((".py", ".pyi", ".pyx"))
+
+
+def is_js(path: str) -> bool:
+    return path.endswith((".js", ".jsx", ".mjs", ".cjs"))
+
+
+def is_supported(path: str) -> bool:
+    return is_python(path) or is_js(path)

--- a/v3-service/graph/facts.py
+++ b/v3-service/graph/facts.py
@@ -1,0 +1,136 @@
+"""CodeGraph → Prolog facts + rules.
+
+Faithful port of chiasmus `src/graph/facts.ts` (`escapeAtom`, `BUILTIN_RULES`,
+`graphToProlog`). Emitted early per the plan so the optional Phase 5 solver layer
+can be added without re-plumbing; nothing consumes it yet beyond the
+`facts` analysis output. The insight facts (communities / hubs / bridges) from
+the original are intentionally omitted.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .types import CodeGraph
+
+_BARE_ATOM = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def escape_atom(s: str) -> str:
+    """Escape a string as a Prolog atom (single-quoted if needed)."""
+    # fullmatch, not match: `$` in re.match also matches just before a trailing
+    # newline, so "foo\n" would slip through unquoted and break the fact.
+    if _BARE_ATOM.fullmatch(s):
+        return s
+    escaped = (
+        s.replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace("\0", "\\0")
+    )
+    return f"'{escaped}'"
+
+
+MEMBER_RULES = """member(X, [X|_]).
+member(X, [_|T]) :- member(X, T)."""
+
+BUILTIN_RULES = (
+    MEMBER_RULES
+    + """
+
+% Cycle-safe reachability via visited list
+reaches(A, B) :- reaches(A, B, [A]).
+reaches(A, B, _) :- calls(A, B).
+reaches(A, B, Visited) :- calls(A, Mid), \\+ member(Mid, Visited), reaches(Mid, B, [Mid|Visited]).
+
+% Path finding (returns the call chain)
+path(A, B, Path) :- path(A, B, [A], Path).
+path(A, B, _, [A, B]) :- calls(A, B).
+path(A, B, Visited, [A|Rest]) :- calls(A, Mid), \\+ member(Mid, Visited), path(Mid, B, [Mid|Visited], Rest).
+
+% Function-only reachability (for cycle detection). Methods excluded — unqualified
+% method names collide across classes, producing phantom self-loops.
+func_calls(A, B) :- calls(A, B), \\+ defines(_, A, method, _), \\+ defines(_, B, method, _).
+func_reaches(A, B) :- func_reaches(A, B, [A]).
+func_reaches(A, B, _) :- func_calls(A, B).
+func_reaches(A, B, Visited) :- func_calls(A, Mid), \\+ member(Mid, Visited), func_reaches(Mid, B, [Mid|Visited]).
+
+% Dead code: defined function not called by anyone and not an entry point.
+dead(Name) :- defines(_, Name, function, _), \\+ calls(_, Name), \\+ entry_point(Name).
+
+% Convenience predicates
+caller_of(Target, Caller) :- calls(Caller, Target).
+callee_of(Source, Callee) :- calls(Source, Callee)."""
+)
+
+
+def graph_to_prolog(graph: CodeGraph, entry_points=None) -> str:
+    """Render a CodeGraph as a Prolog program (facts + built-in rules)."""
+    lines = [
+        ":- dynamic(defines/4).",
+        ":- dynamic(calls/2).",
+        ":- dynamic(imports/3).",
+        ":- dynamic(exports/2).",
+        ":- dynamic(contains/2).",
+        ":- dynamic(file/2).",
+        ":- dynamic(entry_point/1).",
+        "",
+    ]
+
+    for f in graph.files:
+        lines.append(f"file({escape_atom(f.path)}, {escape_atom(f.language)}).")
+    if graph.files:
+        lines.append("")
+
+    for d in graph.defines:
+        lines.append(
+            f"defines({escape_atom(d.file)}, {escape_atom(d.name)}, "
+            f"{escape_atom(d.kind)}, {d.line})."
+        )
+    if graph.defines:
+        lines.append("")
+
+    for c in graph.calls:
+        lines.append(f"calls({escape_atom(c.caller)}, {escape_atom(c.callee)}).")
+    if graph.calls:
+        lines.append("")
+
+    for i in graph.imports:
+        lines.append(
+            f"imports({escape_atom(i.file)}, {escape_atom(i.name)}, {escape_atom(i.source)})."
+        )
+    if graph.imports:
+        lines.append("")
+
+    resolved_rows = [i for i in graph.imports if i.resolved]
+    if resolved_rows:
+        lines.append(":- dynamic(imports_resolved/3).")
+        for i in resolved_rows:
+            lines.append(
+                f"imports_resolved({escape_atom(i.file)}, {escape_atom(i.name)}, "
+                f"{escape_atom(i.resolved)})."
+            )
+        lines.append("")
+
+    for e in graph.exports:
+        lines.append(f"exports({escape_atom(e.file)}, {escape_atom(e.name)}).")
+    if graph.exports:
+        lines.append("")
+
+    for c in graph.contains:
+        lines.append(f"contains({escape_atom(c.parent)}, {escape_atom(c.child)}).")
+    if graph.contains:
+        lines.append("")
+
+    if entry_points:
+        for ep in entry_points:
+            lines.append(f"entry_point({escape_atom(ep)}).")
+    else:
+        for name in dict.fromkeys(e.name for e in graph.exports):
+            lines.append(f"entry_point({escape_atom(name)}).")
+    lines.append("")
+
+    lines.append(BUILTIN_RULES)
+    return "\n".join(lines)

--- a/v3-service/graph/flags.py
+++ b/v3-service/graph/flags.py
@@ -1,0 +1,20 @@
+"""Feature-flag contract for the structural call-graph layer (issue #39).
+
+The graph package is always importable and side-effect free. Whether the
+pipeline uses it (deeper structural veto, multi-hop repair context, graph-scoped
+context injection) is gated by `ATLAS_CALL_GRAPH`, checked before any of those
+paths diverge from current behavior. Default off.
+"""
+
+from __future__ import annotations
+
+import os
+
+ENV_VAR = "ATLAS_CALL_GRAPH"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def call_graph_enabled() -> bool:
+    """True when the call-graph layer is enabled. Default: off."""
+    return os.getenv(ENV_VAR, "0").strip().lower() in _TRUTHY

--- a/v3-service/graph/resolve.py
+++ b/v3-service/graph/resolve.py
@@ -1,0 +1,61 @@
+"""Python import resolution: fill ImportsFact.resolved with an in-batch file.
+
+Python has no tsconfig, so this is the analogue of chiasmus's suffix-index
+import resolution (`src/graph/suffix-index.ts`) adapted to Python module paths:
+map a file's repo-relative path to its dotted module name, then resolve an
+import specifier to the file that defines it. Best-effort and cross-file aware;
+unresolved specifiers (stdlib, third-party, dynamic) are left as None.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .types import CodeGraph
+
+
+def _module_name(rel_path: str) -> str:
+    p = rel_path
+    if p.endswith("/__init__.py"):
+        p = p[: -len("/__init__.py")]
+    elif p.endswith(".py"):
+        p = p[: -len(".py")]
+    elif p.endswith((".pyi", ".pyx")):
+        p = p.rsplit(".", 1)[0]
+    return p.replace("/", ".").replace("\\", ".").strip(".")
+
+
+def resolve_imports(graph: CodeGraph, file_paths: List[str]) -> None:
+    """Fill `resolved` on each ImportsFact in place. `file_paths` is every
+    repo-relative path in the extraction batch."""
+    # module dotted name -> file path. Last write wins on collision, which is
+    # fine for our best-effort resolution.
+    module_to_file: Dict[str, str] = {}
+    for path in file_paths:
+        if path.endswith((".py", ".pyi", ".pyx")):
+            module_to_file[_module_name(path)] = path
+
+    if not module_to_file:
+        return
+
+    modules = list(module_to_file.keys())
+    for imp in graph.imports:
+        src = imp.source.strip().lstrip(".")  # relative-import dots dropped
+        if not src:
+            continue
+        # 1. `from pkg import mod` where pkg/mod.py exists -> prefer the submodule
+        #    file (where mod's code lives) over pkg/__init__.py. Checked first so
+        #    a submodule import points at the submodule, not the package init.
+        candidate = f"{src}.{imp.name}" if imp.name else src
+        if candidate in module_to_file:
+            imp.resolved = module_to_file[candidate]
+            continue
+        # 2. exact module match (covers `import pkg.mod` and `from pkg.mod import x`)
+        if src in module_to_file:
+            imp.resolved = module_to_file[src]
+            continue
+        # 3. suffix match: a bare `import mod` resolves to any `*/mod`.
+        suffix = f".{src}"
+        hits = [m for m in modules if m == src or m.endswith(suffix)]
+        if len(hits) == 1:
+            imp.resolved = module_to_file[hits[0]]

--- a/v3-service/graph/resolve_calls.py
+++ b/v3-service/graph/resolve_calls.py
@@ -1,0 +1,215 @@
+"""Graph-backed call resolution for the structural veto (issue #39, Phase 1).
+
+The shipped veto (v3-service `structural_score`) accepts a bare call name if ANY
+project file defines a top-level symbol with that name, even when the candidate
+never imports it. That lets through genuine broken cross-file references (a
+NameError the sandbox can miss on an unexecuted path). This module resolves
+direct-identifier calls precisely against the import graph instead:
+
+- a call resolves if its name is defined locally, is a builtin, is an imported
+  name, or is supplied by a wildcard import whose module's *actual* exports
+  include it (resolved via the call graph, not blanket-accepted);
+- when a wildcard import can't be resolved to an in-batch file (stdlib /
+  third-party), resolution is treated as uncertain and nothing is flagged
+  (conservative, matching today's leniency);
+- attribute / method calls (`obj.foo()`) are out of scope, exactly as the
+  shipped veto, because the receiver type isn't statically known.
+
+`strict=False` restores the old behavior (accept any project symbol) so the veto
+can be tightened gradually.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Set
+
+from . import extract as _extract
+from .resolve import resolve_imports
+from .types import CodeGraph
+
+# Compact builtin set; the caller (v3-service) can pass its fuller PY_BUILTINS.
+_DEFAULT_BUILTINS = frozenset({
+    "print", "len", "range", "int", "str", "float", "bool", "list", "dict",
+    "tuple", "set", "frozenset", "type", "isinstance", "issubclass", "getattr",
+    "setattr", "hasattr", "super", "open", "enumerate", "zip", "map", "filter",
+    "sorted", "reversed", "sum", "min", "max", "abs", "round", "any", "all",
+    "repr", "format", "iter", "next", "id", "hash", "ord", "chr", "bytes",
+    "bytearray", "object", "property", "staticmethod", "classmethod", "vars",
+    "dir", "callable", "exec", "eval", "globals", "locals", "input",
+})
+
+
+def direct_call_names(code: str) -> List[str]:
+    """Direct-identifier call targets in `code` (e.g. `foo()`), in source order.
+    Skips attribute/subscript/chained calls — those need receiver-type info the
+    static graph doesn't have. Mirrors v3-service `_extract_python_call_targets`."""
+    if not _extract.available():
+        return []
+    try:
+        parser = _extract._ts.Parser(_extract._PY_LANG)
+        tree = parser.parse(bytes(code, "utf-8"))
+    except Exception:
+        return []
+    out: List[str] = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if node.type == "call":
+            for child in node.children:
+                if child.type == "identifier":
+                    out.append(_extract._text(child))
+                    break
+                if child.type != "(":
+                    break  # attribute / subscript → skip
+        stack.extend(node.children)
+    return out
+
+
+def _collect_identifiers(node, out: Set[str]) -> None:
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "identifier":
+            out.add(_extract._text(n))
+        for i in range(n.child_count):
+            stack.append(n.child(i))
+
+
+def bound_names(code: str) -> Set[str]:
+    """Every name bound anywhere in the file: def/class names, function and
+    lambda parameters, assignment / walrus / augmented-assignment targets, loop
+    variables, `with`/`except as` aliases, and global/nonlocal declarations.
+
+    A call to a name in this set must NOT be flagged unresolved — it could be a
+    local, a parameter, or an assigned callable. Over-collecting (e.g. picking up
+    identifiers inside parameter type annotations) is deliberately safe: it can
+    only cause the veto to MISS a bug, never to reject valid code. Without this,
+    `def run(cb): return cb()` and `x = lambda: 1; x()` are false positives.
+    """
+    if not _extract.available():
+        return set()
+    try:
+        parser = _extract._ts.Parser(_extract._PY_LANG)
+        tree = parser.parse(bytes(code, "utf-8"))
+    except Exception:
+        return set()
+
+    names: Set[str] = set()
+    stack = [tree.root_node]
+    while stack:
+        n = stack.pop()
+        t = n.type
+        if t in ("function_definition", "class_definition"):
+            nm = n.child_by_field_name("name")
+            if nm is not None:
+                names.add(_extract._text(nm))
+        elif t in ("parameters", "lambda_parameters"):
+            _collect_identifiers(n, names)
+        elif t in ("assignment", "augmented_assignment"):
+            left = n.child_by_field_name("left")
+            if left is not None:
+                _collect_identifiers(left, names)
+        elif t == "named_expression":
+            # walrus `(g := ...)` — tree-sitter names the target field `name`.
+            target = n.child_by_field_name("name")
+            if target is not None:
+                _collect_identifiers(target, names)
+        elif t in ("for_statement", "for_in_clause"):
+            left = n.child_by_field_name("left")
+            if left is not None:
+                _collect_identifiers(left, names)
+        elif t == "as_pattern":
+            alias = n.child_by_field_name("alias")
+            if alias is not None:
+                _collect_identifiers(alias, names)
+        elif t in ("global_statement", "nonlocal_statement"):
+            _collect_identifiers(n, names)
+        for i in range(n.child_count):
+            stack.append(n.child(i))
+    return names
+
+
+def _defs_by_file(graph: CodeGraph) -> Dict[str, Set[str]]:
+    out: Dict[str, Set[str]] = {}
+    for d in graph.defines:
+        out.setdefault(d.file, set()).add(d.name)
+    return out
+
+
+def unresolved_calls(
+    candidate_path: str,
+    candidate_code: str,
+    project_files: Optional[Dict[str, str]] = None,
+    builtins: Optional[Set[str]] = None,
+    strict: bool = True,
+) -> dict:
+    """Resolve the candidate's direct calls against the import graph.
+
+    Returns {"ok", "unresolved": [...], "n_calls_total", "lenient": bool}.
+    `lenient` is True when an unresolvable wildcard import means nothing can be
+    confidently flagged. `ok=False` (with "error") when extraction is unavailable.
+    """
+    if not _extract.available():
+        return {"ok": False, "error": "tree-sitter not installed"}
+
+    project_files = project_files or {}
+    builtins = builtins or set(_DEFAULT_BUILTINS)
+
+    cand = _extract.extract_file(candidate_path, candidate_code)
+    # All names bound anywhere in the file (params, locals, assignments, defs),
+    # not just def/class names — otherwise callbacks and assigned callables
+    # false-positive. See bound_names.
+    local = bound_names(candidate_code) | {d.name for d in cand.defines}
+    import_names: Set[str] = set()
+    for i in cand.imports:
+        if i.name == "*":
+            continue  # handled below via wildcard resolution
+        import_names.add(i.name)
+        # `import a.b.c` binds only the top package `a` (you'd call a.b.c.x()
+        # as an attribute, never bare `c`). Bind the first segment, not the last.
+        import_names.add(i.name.split(".")[0])
+
+    # Build the project graph (cached) to resolve wildcard modules to their
+    # actual exported names, and for the non-strict project-symbol fallback.
+    all_files = dict(project_files)
+    all_files[candidate_path] = candidate_code
+    from . import build_graph  # local import avoids a cycle at module load
+    proj = build_graph(all_files)
+    defs_by_file = _defs_by_file(proj)
+    project_symbols = {d.name for d in proj.defines}
+
+    # Resolve the candidate's wildcard imports to in-batch files.
+    resolve_imports(cand, list(all_files.keys()))
+    wildcard_names: Set[str] = set()
+    lenient = False
+    for i in cand.imports:
+        if i.name != "*":
+            continue
+        if i.resolved and i.resolved in defs_by_file:
+            wildcard_names |= defs_by_file[i.resolved]
+        else:
+            # Wildcard from an unresolved module (stdlib / third-party): we can't
+            # know what it supplies, so don't flag anything.
+            lenient = True
+
+    resolved = local | set(builtins) | import_names | wildcard_names
+    if not strict:
+        resolved |= project_symbols
+
+    calls = direct_call_names(candidate_code)
+    unresolved: List[str] = []
+    seen: Set[str] = set()
+    if not lenient:
+        for name in calls:
+            if name in resolved or name in seen:
+                continue
+            seen.add(name)
+            unresolved.append(name)
+
+    return {
+        "ok": True,
+        "unresolved": unresolved[:10],
+        "n_unresolved": len(unresolved),
+        "n_calls_total": len(calls),
+        "lenient": lenient,
+    }

--- a/v3-service/graph/types.py
+++ b/v3-service/graph/types.py
@@ -1,0 +1,100 @@
+"""Call-graph data model.
+
+Faithful port of the CodeGraph fact model from chiasmus `src/graph/types.ts`.
+Flat fact tuples (defines / calls / imports / exports / contains) so the graph
+is language-agnostic and translates directly to Prolog facts (see facts.py).
+
+TS/JS-only machinery from the original (qualified-name resolution via receiver
+chains, hyperedges) is intentionally omitted from this Python-first port; it can
+be added with the relevant languages later (issue #39, Phase 6).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# function | method | class | interface | variable
+SymbolKind = str
+
+
+@dataclass
+class DefinesFact:
+    file: str
+    name: str
+    kind: SymbolKind
+    line: int
+    signature: Optional[str] = None
+
+
+@dataclass
+class CallsFact:
+    caller: str
+    callee: str
+    callee_qn: Optional[str] = None  # reserved for languages with QN resolution
+
+
+@dataclass
+class ImportsFact:
+    file: str
+    name: str
+    source: str  # raw specifier as written (module path / dotted name)
+    resolved: Optional[str] = None  # canonical in-batch file path when resolved
+
+
+@dataclass
+class ExportsFact:
+    file: str
+    name: str
+
+
+@dataclass
+class ContainsFact:
+    parent: str
+    child: str
+
+
+@dataclass
+class FileNode:
+    path: str
+    language: str
+    line_count: Optional[int] = None
+
+
+@dataclass
+class CodeGraph:
+    defines: List[DefinesFact] = field(default_factory=list)
+    calls: List[CallsFact] = field(default_factory=list)
+    imports: List[ImportsFact] = field(default_factory=list)
+    exports: List[ExportsFact] = field(default_factory=list)
+    contains: List[ContainsFact] = field(default_factory=list)
+    files: List[FileNode] = field(default_factory=list)
+
+    def merge(self, other: "CodeGraph") -> None:
+        self.defines.extend(other.defines)
+        self.calls.extend(other.calls)
+        self.imports.extend(other.imports)
+        self.exports.extend(other.exports)
+        self.contains.extend(other.contains)
+        self.files.extend(other.files)
+
+    def to_dict(self) -> dict:
+        return {
+            "defines": [
+                {"file": d.file, "name": d.name, "kind": d.kind, "line": d.line,
+                 "signature": d.signature}
+                for d in self.defines
+            ],
+            "calls": [
+                {"caller": c.caller, "callee": c.callee, "calleeQN": c.callee_qn}
+                for c in self.calls
+            ],
+            "imports": [
+                {"file": i.file, "name": i.name, "source": i.source, "resolved": i.resolved}
+                for i in self.imports
+            ],
+            "exports": [{"file": e.file, "name": e.name} for e in self.exports],
+            "contains": [{"parent": c.parent, "child": c.child} for c in self.contains],
+            "files": [{"path": f.path, "language": f.language, "lineCount": f.line_count}
+                      for f in self.files],
+        }

--- a/v3-service/main.py
+++ b/v3-service/main.py
@@ -1438,7 +1438,19 @@ class V3PipelineService:
         if failing:
             failing_func = _failing_function_from_stderr(failing[0].error_output)
             if failing_func and files:
-                chain_context_block = call_chain_context(files, failing_func)
+                # Phase 2 (#39 point 3): when the call graph is enabled, build a
+                # multi-hop reachability slice (entry-point path, transitive
+                # impact, callees) instead of the 1-hop callers/callees block.
+                # Falls back to the shipped builder on flag-off or any failure.
+                chain_context_block = ""
+                try:
+                    from graph import call_graph_enabled as _cg_on, repair_context as _cg_repair
+                    if _cg_on():
+                        chain_context_block = _cg_repair(files, failing_func)
+                except Exception as cge:
+                    print(f"  [phase3] graph repair-context skipped: {cge}", flush=True)
+                if not chain_context_block:
+                    chain_context_block = call_chain_context(files, failing_func)
                 if chain_context_block:
                     emit("call_chain_context",
                          f"Built call-chain for failing `{failing_func}`",
@@ -3160,6 +3172,25 @@ class V3Handler(BaseHTTPRequestHandler):
         n_matched = len(result.get("matched", []))
         n_skipped = len(result.get("skipped", []))
         n_files = len(file_map)
+
+        # Phase 3 (#39 point 4): when the call graph is enabled, attach each
+        # matched symbol's graph neighborhood (callers / callees / impact) so
+        # the proxy can inject structurally related code instead of name-matched
+        # snippets alone. Additive: the "matched"/"skipped" shape is unchanged,
+        # so flag-off callers see exactly today's response.
+        try:
+            from graph import call_graph_enabled, symbol_neighborhood
+            if call_graph_enabled() and result.get("matched"):
+                related = []
+                for m in result["matched"]:
+                    nb = symbol_neighborhood(file_map, m["name"])
+                    if nb["callers"] or nb["callees"] or nb["impact"]:
+                        related.append(nb)
+                if related:
+                    result["graph"] = related
+        except Exception as cge:
+            print(f"  [symbol_index] graph neighborhood skipped: {cge}", flush=True)
+
         print(
             f"  [symbol_index] {n_files} files, {len(symbols)} candidates → "
             f"matched={n_matched} skipped={n_skipped}",
@@ -3197,6 +3228,7 @@ class V3Handler(BaseHTTPRequestHandler):
         try:
             from graph import (
                 build_graph, run_analysis, graph_to_prolog, call_graph_enabled,
+                reachable_pairs,
             )
         except Exception as e:  # pragma: no cover - import guard
             self._json_response(200, {"ok": False, "error": f"graph package unavailable: {e}"})
@@ -3211,7 +3243,13 @@ class V3Handler(BaseHTTPRequestHandler):
         try:
             g = build_graph(file_map)
             if analysis == "facts":
+                # Prolog facts + rules for an external solver (chiasmus_verify / SWI).
                 result = graph_to_prolog(g, entry_points=body.get("entry_points"))
+            elif analysis == "closure":
+                # Phase 5: the transitive reaches/2 relation via the in-process
+                # Datalog engine — a relation the native single-pair API doesn't
+                # expose directly. Returned as [from, to] pairs.
+                result = [list(p) for p in reachable_pairs(g)]
             else:
                 result = run_analysis(
                     g, analysis,

--- a/v3-service/main.py
+++ b/v3-service/main.py
@@ -1317,6 +1317,44 @@ class V3PipelineService:
                 )
             passing = kept
 
+        # ===== CALL-GRAPH VETO (issue #39, Phase 1) =====
+        # Deepens the structural veto using the import graph: reject a candidate
+        # whose direct calls don't resolve to a real, in-scope definition (local,
+        # builtin, imported, or supplied by a resolved wildcard) — not merely
+        # "some project file defines that name." Catches broken cross-file
+        # references the shipped veto accepts. Flag-gated by ATLAS_CALL_GRAPH;
+        # conservative — stays lenient on opaque wildcards and never empties the
+        # candidate set (a fully-failing set falls through intact to repair).
+        if passing and files and file_path:
+            try:
+                from graph import call_graph_enabled, unresolved_calls
+                _cg_on = call_graph_enabled()
+            except Exception:
+                _cg_on = False
+            if _cg_on:
+                cg_kept = []
+                for c in passing:
+                    try:
+                        res = unresolved_calls(
+                            file_path, c.get("code", ""), files,
+                            builtins=set(PY_BUILTINS), strict=True)
+                    except Exception as cge:
+                        print(f"  [call_graph] veto skipped for cand {c.get('index')}: {cge}",
+                              flush=True)
+                        cg_kept.append(c)
+                        continue
+                    if res.get("ok") and res.get("unresolved"):
+                        emit("call_graph_veto",
+                             f"Candidate {c.get('index')} has unresolved call(s): "
+                             f"{', '.join(res['unresolved'][:3])}",
+                             index=c.get("index"), unresolved=res["unresolved"][:5])
+                        print(f"  [call_graph] vetoed cand {c.get('index')} — "
+                              f"unresolved: {res['unresolved'][:5]}", flush=True)
+                        continue
+                    cg_kept.append(c)
+                if cg_kept:  # only prune when at least one candidate survives
+                    passing = cg_kept
+
         # ===== CANDIDATE SELECTION =====
         if passing:
             # S* tiebreaking if multiple passing candidates
@@ -2788,6 +2826,8 @@ class V3Handler(BaseHTTPRequestHandler):
             self._handle_cyclomatic_complexity()
         elif self.path == "/internal/symbol_index":
             self._handle_symbol_index()
+        elif self.path == "/internal/call_graph":
+            self._handle_call_graph()
         elif self.path == "/health":
             self._json_response(200, {"status": "ok"})
         else:
@@ -3126,6 +3166,69 @@ class V3Handler(BaseHTTPRequestHandler):
             flush=True,
         )
         self._json_response(200, result)
+
+    def _handle_call_graph(self):
+        """POST /internal/call_graph — structural call-graph query (issue #39).
+
+        Builds (cached) a project call graph from the supplied files and runs a
+        native analysis on it. No solver; O(V+E) traversal.
+
+        Request:
+            {"file_map": {"app.py": "...", "pkg/util.py": "..."},
+             "analysis": "callers" | "callees" | "reachability" | "path" |
+                         "impact" | "cycles" | "dead-code" | "entry-points" | "facts",
+             "target": "<name>",        # callers/callees/impact
+             "from": "<name>", "to": "<name>",   # reachability/path
+             "entry_points": ["main"]}  # dead-code (optional)
+        Response:
+            {"ok": true, "analysis": "...", "result": <analysis result>}
+            or {"ok": false, "error": "..."}
+
+        Gated by ATLAS_CALL_GRAPH; returns ok=false when the flag is off so the
+        feature stays inert until enabled.
+        """
+        content_len = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(content_len) or b"{}")
+        except json.JSONDecodeError as e:
+            self._json_response(400, {"ok": False, "error": f"invalid JSON body: {e}"})
+            return
+
+        try:
+            from graph import (
+                build_graph, run_analysis, graph_to_prolog, call_graph_enabled,
+            )
+        except Exception as e:  # pragma: no cover - import guard
+            self._json_response(200, {"ok": False, "error": f"graph package unavailable: {e}"})
+            return
+
+        if not call_graph_enabled():
+            self._json_response(200, {"ok": False, "error": "ATLAS_CALL_GRAPH disabled"})
+            return
+
+        file_map = body.get("file_map") or {}
+        analysis = body.get("analysis", "facts")
+        try:
+            g = build_graph(file_map)
+            if analysis == "facts":
+                result = graph_to_prolog(g, entry_points=body.get("entry_points"))
+            else:
+                result = run_analysis(
+                    g, analysis,
+                    target=body.get("target"),
+                    frm=body.get("from"),
+                    to=body.get("to"),
+                    entry_points=body.get("entry_points"),
+                )
+        except ValueError as e:
+            self._json_response(400, {"ok": False, "error": str(e)})
+            return
+        except Exception as e:
+            self._json_response(200, {"ok": False, "error": f"call_graph failed: {e}"})
+            return
+
+        print(f"  [call_graph] {len(file_map)} files, analysis={analysis} → ok", flush=True)
+        self._json_response(200, {"ok": True, "analysis": analysis, "result": result})
 
     def _handle_cyclomatic_complexity(self):
         """POST /internal/cyclomatic_complexity — McCabe CC for tier classification.

--- a/v3-service/main.py
+++ b/v3-service/main.py
@@ -3179,11 +3179,14 @@ class V3Handler(BaseHTTPRequestHandler):
         # snippets alone. Additive: the "matched"/"skipped" shape is unchanged,
         # so flag-off callers see exactly today's response.
         try:
-            from graph import call_graph_enabled, symbol_neighborhood
+            from graph import call_graph_enabled, symbol_neighborhood, build_graph
             if call_graph_enabled() and result.get("matched"):
+                # Build the project graph ONCE, then neighborhood each matched
+                # symbol against it (not once per symbol).
+                g = build_graph(file_map)
                 related = []
                 for m in result["matched"]:
-                    nb = symbol_neighborhood(file_map, m["name"])
+                    nb = symbol_neighborhood(file_map, m["name"], graph=g)
                     if nb["callers"] or nb["callees"] or nb["impact"]:
                         related.append(nb)
                 if related:


### PR DESCRIPTION
Adds a precomputed, cached call graph and rewires the structural veto to use it, behind ATLAS_CALL_GRAPH (default off, strictly additive). This is the deeper solver-backed layer that issue #39 asked for but that V3.1 never landed: there was no stored call graph, no transitive reachability, and the veto was a shape check rather than real resolution.

The graph engine in v3-service/graph/ is a faithful Python port of the chiasmus call-graph engine. It extracts defines, calls, imports, exports, and contains facts from tree-sitter, resolves Python imports across files, and answers callers, callees, reachability, path, impact, cycles, dead-code, and entry-points natively in linear time.

I omitted the solver since everyday queries are native graph traversal, and Prolog facts are emitted (facts.py) only so an optional solver layer can be added later without re-plumbing if genuinely useful. A per-file content-hash cache makes recompute incremental.

Golden tests compare against chiasmus's own extractGraph and native-analyses of a fixture with classes, methods, decorators, comprehension calls, and aliased and relative imports, and the analyses match including path tie-breaks and impact ordering.
