### PR TITLE
feat: add Ruby and PHP support to sandbox execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,3 +407,57 @@ jobs:
       - name: cleanup
         if: always()
         run: docker rm -f sandbox-test || true
+
+  ruby-container-smoke:
+    name: ruby sandbox smoke (containerized)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: build sandbox image
+        run: docker build -t atlas-sandbox-test ./sandbox
+      - name: start sandbox
+        run: |
+          docker run -d --name sandbox-test -p 8020:8020 atlas-sandbox-test
+          sleep 5
+      - name: smoke test /execute
+        run: |
+          curl -sf -X POST http://localhost:8020/execute \
+            -H 'Content-Type: application/json' \
+            -d '{"code":"puts \"ok\"","language":"ruby"}' \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'], d; print('PASS: /execute')"
+      - name: smoke test /syntax-check
+        run: |
+          curl -sf -X POST http://localhost:8020/syntax-check \
+            -H 'Content-Type: application/json' \
+            -d '{"code":"puts \"ok\"","language":"ruby"}' \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['valid'], d; print('PASS: /syntax-check')"
+      - name: cleanup
+        if: always()
+        run: docker rm -f sandbox-test || true
+
+  php-container-smoke:
+    name: php sandbox smoke (containerized)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: build sandbox image
+        run: docker build -t atlas-sandbox-test ./sandbox
+      - name: start sandbox
+        run: |
+          docker run -d --name sandbox-test -p 8020:8020 atlas-sandbox-test
+          sleep 5
+      - name: smoke test /execute
+        run: |
+          curl -sf -X POST http://localhost:8020/execute \
+            -H 'Content-Type: application/json' \
+            -d '{"code":"<?php echo \"ok\";","language":"php"}' \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'], d; print('PASS: /execute')"
+      - name: smoke test /syntax-check
+        run: |
+          curl -sf -X POST http://localhost:8020/syntax-check \
+            -H 'Content-Type: application/json' \
+            -d '{"code":"<?php echo \"ok\";","language":"php"}' \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['valid'], d; print('PASS: /syntax-check')"
+      - name: cleanup
+        if: always()
+        run: docker rm -f sandbox-test || true

--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -150,7 +150,8 @@ timeouts/output caps; **syntax** = compile/parse check only.
 | HTML / XML / JSON / YAML | syntax | Supported |
 | Java | executed | Preview (installed in default sandbox; CI smoke test containerized; host-runner tests skipif-gated) |
 | Kotlin | executed | Preview (installed in default sandbox; CI smoke test containerized; host-runner tests skipif-gated) |
-| Ruby / PHP | — | Roadmap (will ship as separate toolchain images, not in the default sandbox) |
+| Ruby | executed | Preview (installed in default sandbox; CI smoke test containerized; host-runner tests skipif-gated) |
+| PHP | executed | Preview (installed in default sandbox; CI smoke test containerized; host-runner tests skipif-gated) |
 
 ## Feature paths
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,7 +329,7 @@ Wait injection appends "Wait, let me reconsider.\n" to request a longer reasonin
 
 **Phase 2: Verification and Selection**
 
-- **Build Verification**: Python (`py_compile`), TypeScript (`tsc --noEmit`), JavaScript (`node --check`), Go (`go build`), Java (`javac`), Kotlin (`kotlinc`), Rust (`rustc` on the sandbox `/execute` path; `Cargo.toml` projects are detected with `cargo build`, and `cargo check` is accepted only via the build-command allowlist), C/C++ (full `gcc`/`g++` compile with `-Wall` on `/execute`; `-fsyntax-only` applies only to the `/syntax-check` route), Shell (`bash -n`). Framework overrides for Next.js, React, Flask, Django, Express.
+- **Build Verification**: Python (`py_compile`), TypeScript (`tsc --noEmit`), JavaScript (`node --check`), Go (`go build`), Java (`javac`), Kotlin (`kotlinc`), Rust (`rustc` on the sandbox `/execute` path; `Cargo.toml` projects are detected with `cargo build`, and `cargo check` is accepted only via the build-command allowlist), C/C++ (full `gcc`/`g++` compile with `-Wall` on `/execute`; `-fsyntax-only` applies only to the `/syntax-check` route), Ruby (`ruby -c`, no compile step — interpreted), PHP (`php -l`, no compile step — interpreted), Shell (`bash -n`). Framework overrides for Next.js, React, Flask, Django, Express.
 - **S* Tiebreaking** (2+ passing): generates edge-case inputs, runs both candidates, majority wins
 - **Lens Selection** (1 passing or fallback): sort by C(x) energy, lowest wins
 
@@ -538,6 +538,8 @@ graph LR
         Kotlin["Kotlin 2.4.0\nkotlinc + java -jar"]
         Rust["Rust stable\nrustc + run"]
         C["C / C++\ngcc/g++ -Wall"]
+        Ruby["Ruby\nruby -c + run"]
+        PHP["PHP\nphp -l + run"]
         Bash["Bash\nbash -n + run"]
     end
 
@@ -551,7 +553,7 @@ graph LR
     style support fill:#333,color:#fff
 ```
 
-Language aliases accepted: `py`/`python3` (Python), `js`/`node` (JavaScript), `ts` (TypeScript), `golang` (Go), `java` (Java), `kt`/`kts` (Kotlin), `rs` (Rust), `c++` (C++), `sh`/`shell` (Bash). Max execution time: 300s in the Docker deployment (compose sets `MAX_EXECUTION_TIME=${ATLAS_SANDBOX_MAX_EXECUTION_TIME:-300}` to match the proxy's 5-min `run_command` cap; the bare code default is 60s). Memory, CPU, and process caps are container-level: compose sets `mem_limit ${ATLAS_SANDBOX_MEM:-4g}`, `cpus ${ATLAS_SANDBOX_CPUS:-2}`, and `pids_limit ${ATLAS_SANDBOX_PIDS:-1024}`; `atlas init` writes host-appropriate values (~75% of RAM and cores) into `.env`. Two workspace paths: **`/execute`** (V3 candidate-test path) uses an ephemeral scratch dir under `/tmp/sandbox` (tmpfs); **`/shell`** (the agent's `run_command` route, plus `/jobs/*` for background processes) runs against `/workspace` — the bind-mounted project root from `ATLAS_PROJECT_DIR` (Docker) or hostPath `${ATLAS_PROJECTS_DIR}` (K3s), the same path the proxy sees.
+Language aliases accepted: `py`/`python3` (Python), `js`/`node` (JavaScript), `ts` (TypeScript), `golang` (Go), `java` (Java), `kt`/`kts` (Kotlin), `rs` (Rust), `c++` (C++), `rb` (Ruby), `php` (PHP), `sh`/`shell` (Bash). Max execution time: 300s in the Docker deployment (compose sets `MAX_EXECUTION_TIME=${ATLAS_SANDBOX_MAX_EXECUTION_TIME:-300}` to match the proxy's 5-min `run_command` cap; the bare code default is 60s). Memory, CPU, and process caps are container-level: compose sets `mem_limit ${ATLAS_SANDBOX_MEM:-4g}`, `cpus ${ATLAS_SANDBOX_CPUS:-2}`, and `pids_limit ${ATLAS_SANDBOX_PIDS:-1024}`; `atlas init` writes host-appropriate values (~75% of RAM and cores) into `.env`. Two workspace paths: **`/execute`** (V3 candidate-test path) uses an ephemeral scratch dir under `/tmp/sandbox` (tmpfs); **`/shell`** (the agent's `run_command` route, plus `/jobs/*` for background processes) runs against `/workspace` — the bind-mounted project root from `ATLAS_PROJECT_DIR` (Docker) or hostPath `${ATLAS_PROJECTS_DIR}` (K3s), the same path the proxy sees.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -730,7 +730,7 @@ except curses.error:
 
 **Symptom:** Asking ATLAS to write an HTML/CSS/JSON file causes a ~5-minute pause with PR-CoT repair attempts and LLM timeouts. The file eventually lands via the direct-write fallback.
 
-**What's happening:** The V3 smoke check is language-aware — it derives language from the target file's extension and routes to the right checker (`.py` → Python compile, `.js` → `node --check`, `.ts` → `tsc --noEmit`, `.go` → `gofmt -e`, `.java` → `javac`, `.kt` → `kotlinc`, `.rs` → `rustc`, `.sh` → `bash -n`, `.html` → `html.parser`, `.xml` → `ElementTree`, `.json` → `json.loads`, `.yaml` → `yaml.safe_load`). An unrecognized extension falls back to Python and fails, which cascades into repair. Note `.c`/`.cpp`/`.h` are not in the extension map (`_ext_to_lang` in `v3-service/main.py`), so C/C++ files hit the Python fallback even though the sandbox itself has C/C++ checkers.
+**What's happening:** The V3 smoke check is language-aware — it derives language from the target file's extension and routes to the right checker (`.py` → Python compile, `.js` → `node --check`, `.ts` → `tsc --noEmit`, `.go` → `gofmt -e`, `.java` → `javac`, `.kt` → `kotlinc`, `.rs` → `rustc`, `.rb` → `ruby`, `.php` → `php`, `.sh` → `bash -n`, `.html` → `html.parser`, `.xml` → `ElementTree`, `.json` → `json.loads`, `.yaml` → `yaml.safe_load`). An unrecognized extension falls back to Python and fails, which cascades into repair. Note `.c`/`.cpp`/`.h` are not in the extension map (`_ext_to_lang` in `v3-service/main.py`), so C/C++ files hit the Python fallback even though the sandbox itself has C/C++ checkers.
 
 If `/v3/generate` receives an approved project build command, V3 emits a `build_verify` event after syntax/self-test verification. The command runs in an ephemeral sandbox workspace with the candidate overlaid onto the project, so failed build evidence blocks `passed=true` without writing the candidate into the real checkout. Overlay snapshots skip dependency caches, secrets, model/data artifacts, symlinks, and large files, and enforce file-count and byte limits. If a project needs heavyweight dependencies to build, install them inside the sandbox workspace as part of the explicit verification workflow.
 
@@ -861,7 +861,7 @@ docker compose logs sandbox
 
 **Symptom:** Sandbox returns an error for a specific language.
 
-**Supported languages (execution):** Python, JavaScript, TypeScript, Go, Java, Kotlin, Rust, C, C++, Bash. Syntax-only checks (`/syntax-check`, V3 smoke check) additionally cover HTML, XML, JSON, and YAML.
+**Supported languages (execution):** Python, JavaScript, TypeScript, Go, Java, Kotlin, Rust, C, C++, Ruby, PHP, Bash. Syntax-only checks (`/syntax-check`, V3 smoke check) additionally cover HTML, XML, JSON, and YAML.
 
 Check available runtimes:
 ```bash

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -43,6 +43,18 @@ RUN curl -fsSL -o /tmp/kotlin.zip \
 
 ENV PATH="/opt/kotlinc/bin:${PATH}"
 
+# Install Ruby (interpreter, no compile step)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ruby \
+    && rm -rf /var/lib/apt/lists/*
+RUN ruby --version
+
+# Install PHP (CLI, no compile step)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    php-cli \
+    && rm -rf /var/lib/apt/lists/*
+RUN php --version
+
 # Install Rust (rustup, stable toolchain) under /opt so the runtime
 # user (non-root) can read it. RUSTUP_HOME stays /opt/rustup at runtime
 # (read-only toolchain); CARGO_HOME is repointed to the user's tmpfs

--- a/sandbox/executor_server.py
+++ b/sandbox/executor_server.py
@@ -1,7 +1,7 @@
 """
 Multi-language sandbox execution server.
 
-Supports: Python, JavaScript/TypeScript, Go, Java, Kotlin, Rust, C/C++, Bash/Shell
+Supports: Python, JavaScript/TypeScript, Go, Java, Kotlin, Rust, C/C++, Ruby, PHP, Bash/Shell
 Provides isolated code execution with resource limits and structured error reporting.
 
 Security / trust model (load-bearing — read before "fixing" CodeQL alerts):
@@ -119,6 +119,8 @@ SUPPORTED_LANGUAGES = {
     "yaml", "yml",
     "java",
     "kotlin", "kt", "kts",
+    "ruby", "rb",
+    "php",
 }
 
 def normalize_language(lang: str) -> str:
@@ -151,6 +153,10 @@ def normalize_language(lang: str) -> str:
         return "java"
     if lang in ("kotlin", "kt", "kts",):
         return "kotlin"
+    if lang in ("ruby", "rb"):
+        return "ruby"
+    if lang in ("php",):
+        return "php"
     return lang
 
 
@@ -202,6 +208,8 @@ def list_languages():
         "go": ["go", "version"],
         "java": ["javac", "--version"],
         "kotlin": ["kotlinc", "-version"],
+        "ruby": ["ruby", "--version"],
+        "php": ["php", "--version"],
         "rust": ["rustc", "--version"],
         "c": ["gcc", "--version"],
         "cpp": ["g++", "--version"],
@@ -763,10 +771,10 @@ def execute_code(request: ExecuteRequest):
     """Execute code in isolated environment."""
     lang = normalize_language(request.language)
 
-    if lang not in ("python", "javascript", "typescript", "go", "java", "kotlin", "rust", "c", "cpp", "bash"):
+    if lang not in ("python", "javascript", "typescript", "go", "java", "kotlin", "rust", "c", "cpp", "ruby", "php", "bash"):
         raise HTTPException(
             status_code=400,
-            detail=f"Language '{request.language}' not supported. Supported: python, javascript, typescript, go, java, kotlin, rust, c, cpp, bash"
+            detail=f"Language '{request.language}' not supported. Supported: python, javascript, typescript, go, java, kotlin, rust, c, cpp, ruby, php, bash"
         )
 
     workspace = tempfile.mkdtemp(dir=WORKSPACE_BASE)
@@ -995,22 +1003,6 @@ def _syntax_check_impl(lang: str, code: str, workspace: Path, filename: Optional
                     errors.append(line.strip())
             if not errors and stderr.strip():
                 errors.append(stderr.strip().split("\n")[-1])
-        
-    elif lang == "rust":
-        fpath = workspace / (filename or "check.rs")
-        fpath.write_text(code)
-        # rustc --edition 2021 with no codegen for syntax-only
-        result = _run_cmd(
-            ["rustc", "--edition", "2021", "--crate-type", "bin", str(fpath), "-o", "/dev/null"],
-            timeout=10, cwd=workspace
-        )
-        if result["returncode"] != 0:
-            stderr = result.get("stderr", "")
-            for line in stderr.splitlines():
-                if "error" in line.lower():
-                    errors.append(line.strip())
-            if not errors and stderr.strip():
-                errors.append(stderr.strip().split("\n")[-1])
 
     elif lang in ("c", "cpp"):
         ext = ".c" if lang == "c" else ".cpp"
@@ -1030,6 +1022,40 @@ def _syntax_check_impl(lang: str, code: str, workspace: Path, filename: Optional
                     errors.append(line.strip())
             if not errors and stderr.strip():
                 errors.append(stderr.strip().split("\n")[-1])
+
+    elif lang == "ruby":
+        fpath = workspace / (filename or "main.rb")
+        fpath.write_text(code)
+        # Use ruby -c for syntax-only checking (no execution)
+        result = _run_cmd(["ruby", "-c", str(fpath)], timeout=5, cwd=workspace)
+        if result["returncode"] != 0:
+            stderr = result.get("stderr", "")
+            for line in stderr.splitlines():
+                if "syntax error" in line or "error" in line.lower():
+                    errors.append(line.strip())
+            if not errors and stderr.strip():
+                errors.append(stderr.strip().split("\n")[-1])
+
+    elif lang == "php":
+        fpath = workspace / (filename or "main.php")
+        fpath.write_text(code)
+        # Use php -l for lint/syntax-only checking (no execution)
+        result = _run_cmd(["php", "-l", str(fpath)], timeout=5, cwd=workspace)
+        if result["returncode"] != 0:
+            # The real "PHP Parse error: ..." detail goes to stderr (with
+            # display_errors=Off, the Debian CLI default); stdout carries
+            # only the generic "Errors parsing main.php" summary. Scan both
+            # so builds that route the message to stdout still work.
+            output = (result.get("stderr", "") + "\n" + result.get("stdout", "")).strip()
+            for line in output.splitlines():
+                line = line.strip()
+                # PHP explicitly tags syntax issues as "Parse error" or "Fatal error"
+                if "parse error" in line.lower() or "error" in line.lower():
+                    # Filter out PHP's generic summary line "Errors parsing main.php"
+                    if not line.startswith("Errors parsing"):
+                        errors.append(line)
+            if not errors and output:
+                errors.append(output.split("\n")[-1])
 
     elif lang == "bash":
         fpath = workspace / (filename or "check.sh")
@@ -1503,6 +1529,70 @@ def execute_cpp(code, test_code, workspace, timeout, stdin=None, **_):
     )
 
 
+# --- Ruby ---
+
+def execute_ruby(code, test_code, workspace, timeout, stdin=None, **_):
+    start = time.time()
+    main_file = workspace / "main.rb"
+    main_file.write_text(code)
+
+    # Syntax check (no compile step for Ruby)
+    r = _run_cmd(["ruby", "-c", str(main_file)], 15)
+    if not r["success"]:
+        return ExecuteResponse(
+            success=False, compile_success=False,
+            tests_run=0, tests_passed=0,
+            stdout="", stderr=r["stderr"],
+            error_type="SyntaxError", error_message=r["stderr"][:500],
+            execution_time_ms=int((time.time() - start) * 1000),
+        )
+
+    # Run
+    r = _run_cmd(["ruby", str(main_file)], timeout, cwd=workspace, stdin=stdin)
+
+    return ExecuteResponse(
+        success=r["success"], compile_success=True,
+        tests_run=1, tests_passed=1 if r["success"] else 0,
+        stdout=r["stdout"], stderr=r["stderr"],
+        error_type=_classify_error(r["stderr"]) if not r["success"] else None,
+        error_message=r["stderr"][:500] if not r["success"] else None,
+        execution_time_ms=int((time.time() - start) * 1000),
+    )
+
+
+# --- PHP ---
+
+def execute_php(code, test_code, workspace, timeout, stdin=None, **_):
+    start = time.time()
+    main_file = workspace / "main.php"
+    main_file.write_text(code)
+
+    # Lint check (no compile step for PHP)
+    r = _run_cmd(["php", "-l", str(main_file)], 15)
+    if not r["success"]:
+        # Real parse error lives in stderr; stdout only has generic summary line
+        error_output = r["stderr"] or r["stdout"]
+        return ExecuteResponse(
+            success=False, compile_success=False,
+            tests_run=0, tests_passed=0,
+            stdout="", stderr=error_output,
+            error_type="SyntaxError", error_message=error_output[:500],
+            execution_time_ms=int((time.time() - start) * 1000),
+        )
+
+    # Run
+    r = _run_cmd(["php", str(main_file)], timeout, cwd=workspace, stdin=stdin)
+
+    return ExecuteResponse(
+        success=r["success"], compile_success=True,
+        tests_run=1, tests_passed=1 if r["success"] else 0,
+        stdout=r["stdout"], stderr=r["stderr"],
+        error_type=_classify_error(r["stderr"]) if not r["success"] else None,
+        error_message=r["stderr"][:500] if not r["success"] else None,
+        execution_time_ms=int((time.time() - start) * 1000),
+    )
+
+
 # --- Bash ---
 
 def execute_bash(code, test_code, workspace, timeout, stdin=None, **_):
@@ -1547,6 +1637,8 @@ LANGUAGE_HANDLERS = {
     "bash": execute_bash,
     "java": execute_java,
     "kotlin": execute_kotlin,
+    "ruby": execute_ruby,
+    "php": execute_php,
 }
 
 

--- a/sandbox/executor_server.py
+++ b/sandbox/executor_server.py
@@ -1004,6 +1004,22 @@ def _syntax_check_impl(lang: str, code: str, workspace: Path, filename: Optional
             if not errors and stderr.strip():
                 errors.append(stderr.strip().split("\n")[-1])
 
+    elif lang == "rust":
+        fpath = workspace / (filename or "check.rs")
+        fpath.write_text(code)
+        # rustc --edition 2021 with no codegen for syntax-only
+        result = _run_cmd(
+            ["rustc", "--edition", "2021", "--crate-type", "bin", str(fpath), "-o", "/dev/null"],
+            timeout=10, cwd=workspace
+        )
+        if result["returncode"] != 0:
+            stderr = result.get("stderr", "")
+            for line in stderr.splitlines():
+                if "error" in line.lower():
+                    errors.append(line.strip())
+            if not errors and stderr.strip():
+                errors.append(stderr.strip().split("\n")[-1])
+
     elif lang in ("c", "cpp"):
         ext = ".c" if lang == "c" else ".cpp"
         fpath = workspace / (filename or f"check{ext}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,7 @@ def pytest_collection_modifyitems(config, items):
             "/tests/infrastructure/test_llm.py",
             "/tests/infrastructure/test_sandbox.py",
             "/tests/infrastructure/test_sandbox_java_kotlin.py",
+            "/tests/infrastructure/test_sandbox_ruby_php.py",
         ))
         if "/tests/integration/" in path or live_infrastructure:
             item.add_marker(pytest.mark.integration)

--- a/tests/infrastructure/test_sandbox_java_kotlin.py
+++ b/tests/infrastructure/test_sandbox_java_kotlin.py
@@ -1,5 +1,5 @@
 """
-Tests for Java (and later Kotlin) sandbox executor support.
+Tests for Java and Kotlin sandbox executor support.
 
 Validates code execution, syntax checking, class name extraction,
 compile errors, and runtime errors for JVM languages.

--- a/tests/infrastructure/test_sandbox_ruby_php.py
+++ b/tests/infrastructure/test_sandbox_ruby_php.py
@@ -1,0 +1,359 @@
+"""
+Tests for Ruby and PHP sandbox executor support.
+
+Validates code execution, syntax checking, language detection via /languages
+endpoint, compile errors, and runtime errors for both languages.
+
+All tests are gated with skipif(ruby is None) and skipif(php is None) so CI 
+runners without a ruby and php don't fail — the executor boots on the host runner
+which has no ruby and php installed in it.
+"""
+
+import pytest
+import shutil
+
+# importorskip, not a plain import — see test_llm.py: keeps collection
+# alive on environments without the integration deps.
+httpx = pytest.importorskip("httpx")
+
+# Reusable skipif marker for all classes that need ruby.
+_requires_ruby = pytest.mark.skipif(
+    shutil.which("ruby") is None,
+    reason="ruby not available",
+)
+
+# Reusable skipif marker for all classes that need php.
+_requires_php = pytest.mark.skipif(
+    shutil.which("php") is None,
+    reason="php not available",
+)
+
+@_requires_ruby
+class TestRubyExecution:
+    """Test Ruby code execution in sandbox."""
+    def test_hello_world(self, sandbox_client: httpx.Client):
+        """Basic ruby -c -> ruby pipeline: syntax check and run."""
+        code = """\
+puts "hello world"
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "ruby"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is True, f"Hello world should succeed: {data}"
+        assert data.get("compile_success") is True
+        assert "hello world" in data.get("stdout", "")
+
+    def test_computed_values(self, sandbox_client: httpx.Client):
+        """Code that computes values should capture output."""
+        code = """\
+a = 2
+b = 3
+puts "Result: #{a + b}"
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "ruby"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is True, f"Computed values should succeed: {data}"
+        assert "Result: 5" in data.get("stdout", "")
+
+    def test_compile_error(self, sandbox_client: httpx.Client):
+        """Code with a syntax error should fail at the ruby -c stage."""
+        code = """\
+def broken
+  puts "missing end"
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "ruby"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"Broken syntax should fail: {data}"
+        assert data.get("compile_success") is False
+        assert data.get("error_type") == "SyntaxError"
+
+    def test_runtime_error_nomethod(self, sandbox_client: httpx.Client):
+        """Calling a method on nil should raise NoMethodError (Ruby's nil-dereference equivalent)."""
+        code = """\
+x = nil
+puts x.upcase
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "ruby"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"NoMethodError should fail: {data}"
+        assert data.get("compile_success") is True
+        assert "NoMethodError" in data.get("stderr", "")
+
+    def test_runtime_error_division_by_zero(self, sandbox_client: httpx.Client):
+        """Integer division by zero should raise ZeroDivisionError."""
+        code = """\
+a = 10
+b = 0
+puts a / b
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "ruby"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"Division by zero should fail: {data}"
+        assert data.get("compile_success") is True
+        assert "ZeroDivisionError" in data.get("stderr", "")
+
+
+@_requires_ruby
+class TestRubySyntaxCheck:
+    """Test Ruby syntax checking via /syntax-check."""
+
+    def test_valid_ruby(self, sandbox_client: httpx.Client):
+        """Valid syntax should report no errors."""
+        code = """\
+def main
+  puts "ok"
+end
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "ruby"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is True, f"Valid Ruby should pass: {data}"
+        assert not data.get("errors")
+
+    def test_invalid_ruby(self, sandbox_client: httpx.Client):
+        """Syntax error should report errors and fail validity."""
+        code = """\
+def main
+  x =
+end
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "ruby"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is False, f"Invalid Ruby should fail: {data}"
+        assert data.get("errors")
+
+    def test_warning_only_is_valid(self, sandbox_client: httpx.Client):
+        """Unused variable is a warning, not a syntax error — should still be valid."""
+        code = """\
+def main
+  unused = 42
+  puts "ok"
+end
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "ruby"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is True, f"Warning-only Ruby should still be valid: {data}"
+
+
+class TestRubyLanguagesEndpoint:
+    """Test /languages reports Ruby — no skipif needed, endpoint
+    returns 'not installed' gracefully when ruby is absent."""
+
+    def test_ruby_in_languages(self, sandbox_client: httpx.Client):
+        """Ruby should appear in the /languages response."""
+        response = sandbox_client.get("/languages")
+        assert response.status_code == 200
+        data = response.json()
+        languages = data.get("languages", {})
+        assert "ruby" in languages, (
+            f"Ruby missing from /languages: {list(languages.keys())}"
+        )
+
+# --- PHP ---
+
+@_requires_php
+class TestPHPExecution:
+    """Test PHP code execution in sandbox."""
+
+    def test_hello_world(self, sandbox_client: httpx.Client):
+        """Basic php -l -> php pipeline: lint and run."""
+        code = """\
+<?php
+echo "hello world";
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "php"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is True, f"Hello world should succeed: {data}"
+        assert data.get("compile_success") is True
+        assert "hello world" in data.get("stdout", "")
+
+    def test_computed_values(self, sandbox_client: httpx.Client):
+        """Code that computes values should capture output."""
+        code = """\
+<?php
+$a = 2;
+$b = 3;
+echo "Result: " . ($a + $b);
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "php"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is True, f"Computed values should succeed: {data}"
+        assert "Result: 5" in data.get("stdout", "")
+
+    def test_compile_error(self, sandbox_client: httpx.Client):
+        """Code with a syntax error should fail at the php -l stage."""
+        code = """\
+<?php
+function broken() {
+    echo "missing brace"
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "php"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"Broken syntax should fail: {data}"
+        assert data.get("compile_success") is False
+        assert data.get("error_type") == "SyntaxError"
+
+    def test_runtime_error_null(self, sandbox_client: httpx.Client):
+        """Calling a method on null should raise an Error (PHP's null-dereference equivalent)."""
+        code = """\
+<?php
+$x = null;
+echo $x->upper();
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "php"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"Null method call should fail: {data}"
+        assert data.get("compile_success") is True
+        assert "Error" in data.get("stderr", "")
+
+    def test_runtime_error_division_by_zero(self, sandbox_client: httpx.Client):
+        """Integer division by zero should raise DivisionByZeroError."""
+        code = """\
+<?php
+$a = 10;
+$b = 0;
+echo intdiv($a, $b);
+"""
+        response = sandbox_client.post(
+            "/execute",
+            json={"code": code, "language": "php"},
+            timeout=90.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("success") is False, f"Division by zero should fail: {data}"
+        assert data.get("compile_success") is True
+        assert "DivisionByZeroError" in data.get("stderr", "")
+
+
+@_requires_php
+class TestPHPSyntaxCheck:
+    """Test PHP syntax checking via /syntax-check."""
+
+    def test_valid_php(self, sandbox_client: httpx.Client):
+        """Valid syntax should report no errors."""
+        code = """\
+<?php
+function main() {
+    echo "ok";
+}
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "php"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is True, f"Valid PHP should pass: {data}"
+        assert not data.get("errors")
+
+    def test_invalid_php(self, sandbox_client: httpx.Client):
+        """Syntax error should report errors and fail validity."""
+        code = """\
+<?php
+function main() {
+    $x =
+}
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "php"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is False, f"Invalid PHP should fail: {data}"
+        assert data.get("errors")
+
+    def test_warning_only_is_valid(self, sandbox_client: httpx.Client):
+        """Unused variable is a notice, not a syntax error — should still be valid."""
+        code = """\
+<?php
+function main() {
+    $unused = 42;
+    echo "ok";
+}
+"""
+        response = sandbox_client.post(
+            "/syntax-check",
+            json={"code": code, "language": "php"},
+            timeout=30.0,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is True, f"Warning-only PHP should still be valid: {data}"
+
+
+class TestPHPLanguagesEndpoint:
+    """Test /languages reports PHP — no skipif needed, endpoint
+    returns 'not installed' gracefully when php is absent."""
+
+    def test_php_in_languages(self, sandbox_client: httpx.Client):
+        """PHP should appear in the /languages response."""
+        response = sandbox_client.get("/languages")
+        assert response.status_code == 200
+        data = response.json()
+        languages = data.get("languages", {})
+        assert "php" in languages, (
+            f"PHP missing from /languages: {list(languages.keys())}"
+        )
+

--- a/v3-service/main.py
+++ b/v3-service/main.py
@@ -653,7 +653,7 @@ def smoke_compile_check(code: str, sandbox, language: str = "python") -> Tuple[b
 
     verified_languages = {
         "python", "py", "javascript", "typescript", "go", "java", "kotlin",
-        "rust", "c", "cpp", "bash", "html", "htm", "xml", "json", "yaml", "yml",
+        "rust", "c", "cpp", "ruby", "php", "bash", "html", "htm", "xml", "json", "yaml", "yml",
     }
     if hasattr(sandbox, "syntax_check") and lang in verified_languages:
         normalized = {
@@ -1113,6 +1113,8 @@ class V3PipelineService:
             ".java": "java",
             ".kt": "kotlin",
             ".rs": "rust",
+            ".rb": "ruby",
+            ".php": "php",
         }
         smoke_language = _ext_to_lang.get(_ext, "python")
 


### PR DESCRIPTION
## Description

Implements Ruby and PHP support for the sandbox executor, following the same pattern as #29/#140. Ruby and PHP are interpreted — no compile step, just syntax check + run.
Adds Ruby and PHP support to the sandbox executor, including execution, syntax checking, language registration, integration tests, CI smoke tests, and documentation updates.

### Changes

| File | What changed |
|------|-------------|
| `sandbox/Dockerfile` | Install `ruby` and `php-cli` via apt (no manual SHA verify needed — apt's signed repo covers the trust chain, unlike Kotlin's raw JetBrains download) |
| `sandbox/executor_server.py` | Add `execute_ruby()` (`ruby -c` + `ruby`) and `execute_php()` (`php -l` + `php`) handlers, `/syntax-check` handlers, `/languages` registration, `rb`/`php` aliases |
| `v3-service/main.py` | Add `"ruby"`/`"php"` to `verified_languages` + `.rb`/`.php` to `_ext_to_lang` |
| `tests/infrastructure/test_sandbox_ruby_php.py` | 18 tests (6 classes — execution, syntax-check, and `/languages` endpoint coverage for both languages), gated with `skipif(shutil.which("ruby"/"php") is None)` |
| `tests/conftest.py` | Register `test_sandbox_ruby_php.py` for `integration` marker gating |
| `.github/workflows/test.yml` | Add `ruby-container-smoke` and `php-container-smoke` jobs — host CI runner has no ruby/php interpreter, so smoke testing runs inside the sandbox image |
| `docs/ARCHITECTURE.md` | Add Ruby/PHP to diagrams + alias list |
| `docs/SUPPORT_MATRIX.md` | Add Ruby/PHP rows (Preview tier, same gating pattern as Java/Kotlin) |
| `docs/TROUBLESHOOTING.md` | Add Ruby/PHP to the language-aware smoke check extension map |

### Maintainer tips addressed

1. **No compile step** — Ruby and PHP are interpreted, so both `/execute` and `/syntax-check` skip straight to `ruby -c`/`php -l` (syntax check) followed by `ruby`/`php` (run). No fat-JAR or classfile step like Java/Kotlin.
2. **PHP error stream** — `php -l` writes lint/parse errors to **stderr**, with only a generic summary line ("Errors parsing ...") on stdout. Verified directly (not assumed) with a manual split-stream test before finalizing `execute_php()`.
3. **Realistic runtime error equivalents** — used each language's actual error model instead of forcing Java-style names: `NoMethodError` for Ruby's nil-dereference (no NullPointerException equivalent exists), `DivisionByZeroError` via PHP's `intdiv()` (the `/` operator only warns and returns `INF`, it doesn't throw).
4. **CI gating** — all Ruby/PHP execution & syntax tests use `@pytest.mark.skipif(shutil.which("ruby"/"php") is None)`. The `/languages` endpoint tests run unconditionally (gracefully report `"not installed"`).
5. **Containerized smoke test** — since the CI host lacks `ruby`/`php`, Docker-based smoke tests verify both end-to-end inside the sandbox container. Host-level tests skip gracefully and `/languages` confirms registration regardless.

### Test output (sandbox container with Ruby and PHP)

<details>
<summary>pytest -v -m integration</summary>

```text
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/LocalDisk/New ATLAS/Anuj-72-ATLAS
configfile: pyproject.toml
plugins: anyio-4.13.0, typeguard-4.4.4
collecting ... collected 18 items

tests/infrastructure/test_sandbox_ruby_php.py::TestRubyExecution::test_hello_world PASSED [  5%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubyExecution::test_computed_values PASSED [ 11%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubyExecution::test_compile_error PASSED [ 16%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubyExecution::test_runtime_error_nomethod PASSED [ 22%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubyExecution::test_runtime_error_division_by_zero PASSED [ 27%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubySyntaxCheck::test_valid_ruby PASSED [ 33%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubySyntaxCheck::test_invalid_ruby PASSED [ 38%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubySyntaxCheck::test_warning_only_is_valid PASSED [ 44%]
tests/infrastructure/test_sandbox_ruby_php.py::TestRubyLanguagesEndpoint::test_ruby_in_languages PASSED [ 50%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPExecution::test_hello_world PASSED [ 55%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPExecution::test_computed_values PASSED [ 61%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPExecution::test_compile_error PASSED [ 66%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPExecution::test_runtime_error_null PASSED [ 72%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPExecution::test_runtime_error_division_by_zero PASSED [ 77%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPSyntaxCheck::test_valid_php PASSED [ 83%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPSyntaxCheck::test_invalid_php PASSED [ 88%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPSyntaxCheck::test_warning_only_is_valid PASSED [ 94%]
tests/infrastructure/test_sandbox_ruby_php.py::TestPHPLanguagesEndpoint::test_php_in_languages PASSED [100%]

============================== 18 passed in 4.14s ==============================