### PR TITLE
Add MiniMax remote generation provider path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,18 @@ ATLAS_MODEL_FILE=
 # Model identifier (required; normally the filename without .gguf)
 ATLAS_MODEL_NAME=
 
+# --- Generation provider (optional) ---
+# Default is the local llama-server. Set to `minimax` to route generation to
+# the MiniMax remote API instead. The MiniMax keys below apply only then; the
+# llama model/sizing keys above are ignored for that provider.
+# ATLAS_LLM_PROVIDER=llama
+# MiniMax region endpoint: global_en (api.minimax.io) | cn_zh (api.minimaxi.com)
+# ATLAS_MINIMAX_REGION=global_en
+# MiniMax model id: MiniMax-M3 (default) | MiniMax-M2.7
+# ATLAS_MINIMAX_MODEL=MiniMax-M3
+# MiniMax Bearer credential (required when ATLAS_LLM_PROVIDER=minimax)
+# ATLAS_MINIMAX_API_KEY=
+
 # Context window size (tokens) — TOTAL across all parallel slots.
 # llama-server divides this by ATLAS_PARALLEL_SLOTS for per-slot context.
 # Size it (and the runtime-sizing keys below) for YOUR model + GPU with:

--- a/atlas/cli/client.py
+++ b/atlas/cli/client.py
@@ -17,12 +17,80 @@ SANDBOX_URL = compose_config.service_url("sandbox")
 MODEL_NAME = os.environ.get("ATLAS_MODEL_NAME", "local-model")
 
 
-def _post(url: str, body: dict, timeout: int = 120) -> dict:
+# --- Provider selection ---
+# The default backend is the local llama-server (OpenAI-compatible, no auth).
+# Setting ATLAS_LLM_PROVIDER=minimax routes the generation calls to the
+# MiniMax remote API instead: a region-scoped OpenAI-compatible base URL, a
+# MiniMax model id, and a Bearer credential. Health, embedding, lens, and
+# sandbox calls are local services and stay on their own URLs regardless of
+# the selected provider.
+_LLAMA_PROVIDER = "llama"
+_MINIMAX_PROVIDER = "minimax"
+
+# Region -> OpenAI-compatible base URL. Each value already carries the /v1
+# suffix, so request paths append "/chat/completions" and "/completions".
+_MINIMAX_OPENAI_BASE_URLS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+_MINIMAX_DEFAULT_REGION = "global_en"
+_MINIMAX_MODELS = ("MiniMax-M3", "MiniMax-M2.7")
+_MINIMAX_DEFAULT_MODEL = "MiniMax-M3"
+
+
+def _provider() -> str:
+    """Active generation provider (defaults to the local llama-server)."""
+    name = (os.environ.get("ATLAS_LLM_PROVIDER") or _LLAMA_PROVIDER).strip().lower()
+    return _MINIMAX_PROVIDER if name == _MINIMAX_PROVIDER else _LLAMA_PROVIDER
+
+
+def _minimax_region() -> str:
+    region = (os.environ.get("ATLAS_MINIMAX_REGION")
+              or _MINIMAX_DEFAULT_REGION).strip().lower()
+    return region if region in _MINIMAX_OPENAI_BASE_URLS else _MINIMAX_DEFAULT_REGION
+
+
+def _openai_base() -> str:
+    """OpenAI-compatible base URL for the active provider (no trailing slash).
+
+    For llama-server this is the local `.../v1`, keeping the historical
+    request paths byte-for-byte; for MiniMax it is the region endpoint.
+    """
+    if _provider() == _MINIMAX_PROVIDER:
+        return _MINIMAX_OPENAI_BASE_URLS[_minimax_region()]
+    return f"{INFERENCE_URL}/v1"
+
+
+def _model_name() -> str:
+    """Model id sent in generation requests for the active provider."""
+    if _provider() == _MINIMAX_PROVIDER:
+        model = (os.environ.get("ATLAS_MINIMAX_MODEL")
+                 or _MINIMAX_DEFAULT_MODEL).strip()
+        return model if model in _MINIMAX_MODELS else _MINIMAX_DEFAULT_MODEL
+    return MODEL_NAME
+
+
+def _auth_headers() -> Dict[str, str]:
+    """Authorization headers for the active generation provider.
+
+    The local llama-server needs none; MiniMax authorizes with a Bearer
+    credential read from ATLAS_MINIMAX_API_KEY.
+    """
+    if _provider() == _MINIMAX_PROVIDER:
+        key = (os.environ.get("ATLAS_MINIMAX_API_KEY") or "").strip()
+        if key:
+            return {"Authorization": f"Bearer {key}"}
+    return {}
+
+
+def _post(url: str, body: dict, timeout: int = 120,
+          headers: Optional[Dict[str, str]] = None) -> dict:
     """POST JSON, return parsed response."""
     data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
-    )
+    req_headers = {"Content-Type": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    req = urllib.request.Request(url, data=data, headers=req_headers)
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
@@ -76,9 +144,10 @@ def check_sandbox() -> Tuple[bool, str]:
 def generate(prompt: str, max_tokens: int = 8192,
              temperature: float = 0.6, stop: Optional[List[str]] = None,
              timeout: int = 900) -> dict:
-    """Generate via llama-server /v1/completions (raw prompt, includes thinking)."""
+    """Generate via the provider's OpenAI-compatible /completions endpoint
+    (raw prompt, includes thinking)."""
     body = {
-        "model": MODEL_NAME,
+        "model": _model_name(),
         "prompt": prompt,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -87,18 +156,20 @@ def generate(prompt: str, max_tokens: int = 8192,
     }
     if stop:
         body["stop"] = stop
-    return _post(f"{INFERENCE_URL}/v1/completions", body, timeout=timeout)
+    return _post(f"{_openai_base()}/completions", body, timeout=timeout,
+                 headers=_auth_headers())
 
 
 def generate_stream(prompt: str, max_tokens: int = 8192,
                     temperature: float = 0.6, stop: Optional[List[str]] = None,
                     timeout: int = 900):
-    """Stream generation via llama-server /v1/completions with stream=true.
+    """Stream generation via the provider's /completions endpoint with
+    stream=true.
 
     Yields (token_text, is_done) tuples.
     """
     body = {
-        "model": MODEL_NAME,
+        "model": _model_name(),
         "prompt": prompt,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -111,9 +182,10 @@ def generate_stream(prompt: str, max_tokens: int = 8192,
 
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
-        f"{INFERENCE_URL}/v1/completions",
+        f"{_openai_base()}/completions",
         data=data,
-        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream",
+                 **_auth_headers()},
     )
 
     with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -147,18 +219,20 @@ def generate_stream(prompt: str, max_tokens: int = 8192,
 
 def chat(messages: List[Dict], max_tokens: int = 8192,
          temperature: float = 0.6, timeout: int = 900) -> dict:
-    """Generate via llama-server /v1/chat/completions.
+    """Generate via the provider's OpenAI-compatible /chat/completions.
 
-    llama-server applies the GGUF's own chat template (--jinja), so this
-    stays model-agnostic — no hand-built ChatML markers or stop tokens.
+    llama-server applies the GGUF's own chat template (--jinja) and remote
+    providers apply their own, so this stays model-agnostic — no hand-built
+    ChatML markers or stop tokens.
     """
     body = {
-        "model": MODEL_NAME,
+        "model": _model_name(),
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
     }
-    return _post(f"{INFERENCE_URL}/v1/chat/completions", body, timeout=timeout)
+    return _post(f"{_openai_base()}/chat/completions", body, timeout=timeout,
+                 headers=_auth_headers())
 
 
 def chat_stream(messages: List[Dict], max_tokens: int = 8192,
@@ -170,7 +244,7 @@ def chat_stream(messages: List[Dict], max_tokens: int = 8192,
     tags so callers keep a single thinking-detection path.
     """
     body = {
-        "model": MODEL_NAME,
+        "model": _model_name(),
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -179,9 +253,10 @@ def chat_stream(messages: List[Dict], max_tokens: int = 8192,
 
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
-        f"{INFERENCE_URL}/v1/chat/completions",
+        f"{_openai_base()}/chat/completions",
         data=data,
-        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream",
+                 **_auth_headers()},
     )
 
     in_reasoning = False

--- a/atlas/cli/config_schema.py
+++ b/atlas/cli/config_schema.py
@@ -32,6 +32,12 @@ SCHEMA: Dict[str, Field] = {
     "ATLAS_MODEL_FILE": Field("str"),
     "ATLAS_MODEL_NAME": Field("str"),
     "ATLAS_MODELS_DIR": Field("str"),
+    # Generation provider: the local llama-server (default) or the MiniMax
+    # remote API. The MiniMax knobs below only apply when provider=minimax.
+    "ATLAS_LLM_PROVIDER": Field("enum", enum=("llama", "minimax")),
+    "ATLAS_MINIMAX_REGION": Field("enum", enum=("global_en", "cn_zh")),
+    "ATLAS_MINIMAX_MODEL": Field("enum", enum=("MiniMax-M3", "MiniMax-M2.7")),
+    "ATLAS_MINIMAX_API_KEY": Field("str"),
     "ATLAS_CTX_SIZE": Field("int", min=512, max=2_000_000),
     "ATLAS_PARALLEL_SLOTS": Field("int", min=1, max=64),
     "ATLAS_UBATCH": Field("int", min=1, max=100_000),

--- a/tests/cli/test_client.py
+++ b/tests/cli/test_client.py
@@ -102,3 +102,77 @@ def test_chat_stream_bridges_reasoning_content_into_think_tags(monkeypatch):
     tokens = [text for text, _done in client.chat_stream(
         [{"role": "user", "content": "q"}])]
     assert tokens == ["<think>", "pondering", "</think>", "print(42)"]
+
+
+def _capture_post(monkeypatch):
+    """Replace client._post with a capturing stub; returns the capture dict."""
+    captured = {}
+
+    def fake_post(url, body, timeout=120, headers=None):
+        captured["url"] = url
+        captured["body"] = body
+        captured["headers"] = headers or {}
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    return captured
+
+
+def test_chat_defaults_to_local_llama_without_auth(monkeypatch):
+    """With no provider configured the chat path stays on the local
+    llama-server: the historical /v1 URL, ATLAS_MODEL_NAME, and no auth."""
+    monkeypatch.delenv("ATLAS_LLM_PROVIDER", raising=False)
+    captured = _capture_post(monkeypatch)
+    client.chat([{"role": "user", "content": "q"}])
+    assert captured["url"] == f"{client.INFERENCE_URL}/v1/chat/completions"
+    assert captured["body"]["model"] == client.MODEL_NAME
+    assert "Authorization" not in captured["headers"]
+
+
+def test_chat_minimax_global_endpoint_model_and_bearer(monkeypatch):
+    """provider=minimax routes chat to the global MiniMax endpoint with the
+    default MiniMax model id and a Bearer credential."""
+    monkeypatch.setenv("ATLAS_LLM_PROVIDER", "minimax")
+    monkeypatch.delenv("ATLAS_MINIMAX_REGION", raising=False)
+    monkeypatch.delenv("ATLAS_MINIMAX_MODEL", raising=False)
+    monkeypatch.setenv("ATLAS_MINIMAX_API_KEY", "sample-credential")
+    captured = _capture_post(monkeypatch)
+    client.chat([{"role": "user", "content": "q"}])
+    assert captured["url"] == "https://api.minimax.io/v1/chat/completions"
+    assert captured["body"]["model"] == "MiniMax-M3"
+    assert captured["headers"]["Authorization"] == "Bearer sample-credential"
+
+
+def test_chat_minimax_cn_region_and_model_selection(monkeypatch):
+    """The CN region and an explicit model id are honored."""
+    monkeypatch.setenv("ATLAS_LLM_PROVIDER", "minimax")
+    monkeypatch.setenv("ATLAS_MINIMAX_REGION", "cn_zh")
+    monkeypatch.setenv("ATLAS_MINIMAX_MODEL", "MiniMax-M2.7")
+    monkeypatch.setenv("ATLAS_MINIMAX_API_KEY", "sample-credential")
+    captured = _capture_post(monkeypatch)
+    client.chat([{"role": "user", "content": "q"}])
+    assert captured["url"] == "https://api.minimaxi.com/v1/chat/completions"
+    assert captured["body"]["model"] == "MiniMax-M2.7"
+
+
+def test_minimax_unknown_region_and_model_fall_back_to_defaults(monkeypatch):
+    """Unrecognized region/model values fall back to the global endpoint and
+    the default MiniMax model rather than emitting an invalid request."""
+    monkeypatch.setenv("ATLAS_LLM_PROVIDER", "minimax")
+    monkeypatch.setenv("ATLAS_MINIMAX_REGION", "mars")
+    monkeypatch.setenv("ATLAS_MINIMAX_MODEL", "not-a-model")
+    monkeypatch.setenv("ATLAS_MINIMAX_API_KEY", "sample-credential")
+    captured = _capture_post(monkeypatch)
+    client.generate("hello")
+    assert captured["url"] == "https://api.minimax.io/v1/completions"
+    assert captured["body"]["model"] == "MiniMax-M3"
+
+
+def test_minimax_without_credential_sends_no_auth_header(monkeypatch):
+    """A missing credential must not fabricate an empty Bearer header."""
+    monkeypatch.setenv("ATLAS_LLM_PROVIDER", "minimax")
+    monkeypatch.delenv("ATLAS_MINIMAX_API_KEY", raising=False)
+    captured = _capture_post(monkeypatch)
+    client.chat([{"role": "user", "content": "q"}])
+    assert captured["headers"] == {}
+


### PR DESCRIPTION
Reason: Add a distinct MiniMax remote provider path (regional endpoints, Bearer authorization, MiniMax model ids) so generation is no longer coupled to the local llama-server.

## What changed
- `atlas/cli/client.py`: the generation calls (`generate`, `generate_stream`, `chat`, `chat_stream`) now resolve their base URL, model id, and authorization from the selected provider. The default stays the local llama-server with byte-identical request paths and no auth header; `ATLAS_LLM_PROVIDER=minimax` routes to the MiniMax OpenAI-compatible API with a region-scoped base URL, a MiniMax model id, and a `Bearer` credential. Health, embedding, lens, and sandbox calls remain on their local services.
- `atlas/cli/config_schema.py`: register `ATLAS_LLM_PROVIDER`, `ATLAS_MINIMAX_REGION`, `ATLAS_MINIMAX_MODEL`, and `ATLAS_MINIMAX_API_KEY` so `validate()`/`migrate()` accept them.
- `.env.example`: document the optional provider knobs.
- `tests/cli/test_client.py`: cover the default llama path (unchanged URL/model, no auth) and the MiniMax path (global/CN endpoints, model selection, Bearer header, missing-credential and unknown-value fallbacks).

## Configuration
- `ATLAS_LLM_PROVIDER`: `llama` (default) | `minimax`
- `ATLAS_MINIMAX_REGION`: `global_en` (https://api.minimax.io/v1) | `cn_zh` (https://api.minimaxi.com/v1)
- `ATLAS_MINIMAX_MODEL`: `MiniMax-M3` (default) | `MiniMax-M2.7`
- `ATLAS_MINIMAX_API_KEY`: Bearer credential (required when the minimax provider is selected)

## Checks
- `python -m pytest tests/cli/` → 427 passed, 13 skipped
- `python -m ruff check --select F --ignore F401,F541,F841 atlas/cli/client.py atlas/cli/config_schema.py tests/cli/test_client.py` → clean
