### PR TITLE
chore(ci): scan the TypeScript client with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python, go]
+        language: [python, go, javascript-typescript]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ probes from `scripts/code_quality.py`.
 - Nine real `.env` keys were reported as typos by `atlas config validate`.
 
 
+### CodeQL now scans the TypeScript client
+
+- `javascript-typescript` joins the CodeQL language matrix. The VS Code
+  extension shipped ~5,100 lines of TS/JS that no scanner looked at, so the
+  next client lands on a fully covered tree. The extractor needs no build
+  step, and both Go steps already carry `if: matrix.language == 'go'`.
+- The webview's CSP nonce came from `Math.random()` (the shape every VS Code
+  webview sample uses) and is now `randomBytes(16)` — `js/insecure-randomness`
+  is in the `security-and-quality` pack, and a security token has no business
+  coming from a non-cryptographic PRNG. Not a live hole: `renderHtml`
+  interpolates nothing untrusted and `media/chat.js` writes through
+  `textContent`, so there was no injection point a guessed nonce could unlock.
+
+
 ### Simplification campaign (2026-07-29 → 2026-08)
 
 One component-by-component pass over the whole tree — merge the fragments,

--- a/extensions/vscode/src/ui/chatView.ts
+++ b/extensions/vscode/src/ui/chatView.ts
@@ -3,6 +3,7 @@
 // also appended to a transcript so a re-created webview (sidebar closed and
 // reopened, window reload of the view) can be replayed from scratch.
 
+import { randomBytes } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -743,10 +744,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 }
 
 function getNonce(): string {
-	let text = '';
-	const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-	for (let i = 0; i < 32; i++) {
-		text += possible.charAt(Math.floor(Math.random() * possible.length));
-	}
-	return text;
+	// A CSP nonce is a security token: it must be unguessable, so it comes
+	// from the CSPRNG rather than Math.random(). 16 bytes of hex keeps the
+	// 32-character shape and stays inside the CSP base64-value grammar.
+	return randomBytes(16).toString('hex');
 }


### PR DESCRIPTION
Follow-up 2 from #35 / #145: CodeQL's language matrix was `[python, go]`, so the VS Code extension's TypeScript was the one shipped tree nothing scanned.

## What changed

- `.github/workflows/codeql.yml` — `javascript-typescript` joins the matrix. No build step needed (the JS extractor reads source directly), and both Go steps already carry `if: matrix.language == 'go'`, so the new leg skips them. `category` and `concurrency` are already per-language, so nothing else needed touching.
- `extensions/vscode/src/ui/chatView.ts` — the first finding the new leg reports is ours. The webview's CSP nonce came from `Math.random()` (the shape every VS Code webview sample uses), which trips `js/insecure-randomness` in the `security-and-quality` pack. Now `randomBytes(16).toString('hex')`, keeping the 32-character shape the CSP grammar wants.

Not a live hole, to be clear about severity: `renderHtml` interpolates nothing untrusted and `media/chat.js` writes through `textContent`, so a guessed nonce had no injection point to unlock. Fixed because a security token shouldn't come from a non-cryptographic PRNG regardless.

## Verified

Rebased on current `dev` (`33f57e2`), which already carries `0c2e02c` — follow-up 1 from that same list. That commit touches `chatView.ts` too, but at the `proxyUrl` default (~line 163), nowhere near `getNonce` (~line 740); no conflict.

`extensions/vscode`: `tsc --noEmit` clean, `eslint src test` clean, **133 tests passing** (10 files), production bundle builds. `codeql.yml` parses as YAML with the matrix reading `['python', 'go', 'javascript-typescript']`.

The workflow change itself can only really be proven by running it — the extension's own CI job doesn't cover the CodeQL leg, so the new matrix entry gets its first real exercise on this PR.
